### PR TITLE
Add fixture-based tests and program filtering

### DIFF
--- a/tests/fixtures/calc.json
+++ b/tests/fixtures/calc.json
@@ -1,0 +1,437 @@
+{
+    "program": "/workspace/codetracer-python-recorder/src/trace.py",
+    "args": [
+        "/workspace/codetracer-python-recorder/tests/programs/calc.py"
+    ],
+    "workdir": "/tmp/tmp.pYVZWB9yqr",
+    "steps": [
+        {
+            "step_id": 0,
+            "path_id": 1,
+            "line": 0,
+            "call_key": 2
+        },
+        {
+            "step_id": 1,
+            "path_id": 1,
+            "line": 1,
+            "call_key": 2
+        },
+        {
+            "step_id": 2,
+            "path_id": 1,
+            "line": 6,
+            "call_key": 2
+        },
+        {
+            "step_id": 3,
+            "path_id": 1,
+            "line": 1,
+            "call_key": 3
+        },
+        {
+            "step_id": 4,
+            "path_id": 1,
+            "line": 2,
+            "call_key": 3
+        },
+        {
+            "step_id": 5,
+            "path_id": 1,
+            "line": 3,
+            "call_key": 3
+        },
+        {
+            "step_id": 6,
+            "path_id": 1,
+            "line": 4,
+            "call_key": 3
+        },
+        {
+            "step_id": 7,
+            "path_id": 1,
+            "line": 4,
+            "call_key": 3
+        },
+        {
+            "step_id": 8,
+            "path_id": 1,
+            "line": 6,
+            "call_key": 3
+        }
+    ],
+    "calls": [
+        {
+            "key": 0,
+            "path_id": 1,
+            "line": 0,
+            "name": "<toplevel>",
+            "args": [],
+            "return_value": {
+                "kind": "None",
+                "ti": 1
+            },
+            "step_id": 0,
+            "depth": 0,
+            "parent_key": -1
+        },
+        {
+            "key": 2,
+            "path_id": 1,
+            "line": 0,
+            "name": "<module>",
+            "args": [],
+            "return_value": {
+                "kind": "None",
+                "ti": 1
+            },
+            "step_id": 0,
+            "depth": 1,
+            "parent_key": 0
+        },
+        {
+            "key": 3,
+            "path_id": 1,
+            "line": 1,
+            "name": "foo",
+            "args": [],
+            "return_value": {
+                "kind": "Error",
+                "ti": 1,
+                "msg": "<not supported>"
+            },
+            "step_id": 3,
+            "depth": 2,
+            "parent_key": 2
+        }
+    ],
+    "variables": [
+        [
+            {
+                "name": "__name__",
+                "value": {
+                    "kind": "Error",
+                    "ti": 1,
+                    "msg": "<not supported>"
+                }
+            },
+            {
+                "name": "__doc__",
+                "value": {
+                    "kind": "Error",
+                    "ti": 1,
+                    "msg": "<not supported>"
+                }
+            },
+            {
+                "name": "__package__",
+                "value": {
+                    "kind": "Error",
+                    "ti": 1,
+                    "msg": "<not supported>"
+                }
+            },
+            {
+                "name": "__loader__",
+                "value": {
+                    "kind": "Error",
+                    "ti": 1,
+                    "msg": "<not supported>"
+                }
+            },
+            {
+                "name": "__spec__",
+                "value": {
+                    "kind": "Error",
+                    "ti": 1,
+                    "msg": "<not supported>"
+                }
+            },
+            {
+                "name": "__file__",
+                "value": {
+                    "kind": "Error",
+                    "ti": 1,
+                    "msg": "<not supported>"
+                }
+            },
+            {
+                "name": "__cached__",
+                "value": {
+                    "kind": "Error",
+                    "ti": 1,
+                    "msg": "<not supported>"
+                }
+            },
+            {
+                "name": "__builtins__",
+                "value": {
+                    "kind": "Error",
+                    "ti": 1,
+                    "msg": "<not supported>"
+                }
+            }
+        ],
+        [
+            {
+                "name": "__name__",
+                "value": {
+                    "kind": "Error",
+                    "ti": 1,
+                    "msg": "<not supported>"
+                }
+            },
+            {
+                "name": "__doc__",
+                "value": {
+                    "kind": "Error",
+                    "ti": 1,
+                    "msg": "<not supported>"
+                }
+            },
+            {
+                "name": "__package__",
+                "value": {
+                    "kind": "Error",
+                    "ti": 1,
+                    "msg": "<not supported>"
+                }
+            },
+            {
+                "name": "__loader__",
+                "value": {
+                    "kind": "Error",
+                    "ti": 1,
+                    "msg": "<not supported>"
+                }
+            },
+            {
+                "name": "__spec__",
+                "value": {
+                    "kind": "Error",
+                    "ti": 1,
+                    "msg": "<not supported>"
+                }
+            },
+            {
+                "name": "__file__",
+                "value": {
+                    "kind": "Error",
+                    "ti": 1,
+                    "msg": "<not supported>"
+                }
+            },
+            {
+                "name": "__cached__",
+                "value": {
+                    "kind": "Error",
+                    "ti": 1,
+                    "msg": "<not supported>"
+                }
+            },
+            {
+                "name": "__builtins__",
+                "value": {
+                    "kind": "Error",
+                    "ti": 1,
+                    "msg": "<not supported>"
+                }
+            }
+        ],
+        [
+            {
+                "name": "__name__",
+                "value": {
+                    "kind": "Error",
+                    "ti": 1,
+                    "msg": "<not supported>"
+                }
+            },
+            {
+                "name": "__doc__",
+                "value": {
+                    "kind": "Error",
+                    "ti": 1,
+                    "msg": "<not supported>"
+                }
+            },
+            {
+                "name": "__package__",
+                "value": {
+                    "kind": "Error",
+                    "ti": 1,
+                    "msg": "<not supported>"
+                }
+            },
+            {
+                "name": "__loader__",
+                "value": {
+                    "kind": "Error",
+                    "ti": 1,
+                    "msg": "<not supported>"
+                }
+            },
+            {
+                "name": "__spec__",
+                "value": {
+                    "kind": "Error",
+                    "ti": 1,
+                    "msg": "<not supported>"
+                }
+            },
+            {
+                "name": "__file__",
+                "value": {
+                    "kind": "Error",
+                    "ti": 1,
+                    "msg": "<not supported>"
+                }
+            },
+            {
+                "name": "__cached__",
+                "value": {
+                    "kind": "Error",
+                    "ti": 1,
+                    "msg": "<not supported>"
+                }
+            },
+            {
+                "name": "__builtins__",
+                "value": {
+                    "kind": "Error",
+                    "ti": 1,
+                    "msg": "<not supported>"
+                }
+            },
+            {
+                "name": "foo",
+                "value": {
+                    "kind": "Error",
+                    "ti": 1,
+                    "msg": "<not supported>"
+                }
+            }
+        ],
+        [],
+        [],
+        [
+            {
+                "name": "x",
+                "value": {
+                    "kind": "Int",
+                    "ti": 0,
+                    "i": 1
+                }
+            }
+        ],
+        [
+            {
+                "name": "x",
+                "value": {
+                    "kind": "Int",
+                    "ti": 0,
+                    "i": 2
+                }
+            }
+        ],
+        [
+            {
+                "name": "x",
+                "value": {
+                    "kind": "Int",
+                    "ti": 0,
+                    "i": 2
+                }
+            }
+        ],
+        [
+            {
+                "name": "__name__",
+                "value": {
+                    "kind": "Error",
+                    "ti": 1,
+                    "msg": "<not supported>"
+                }
+            },
+            {
+                "name": "__doc__",
+                "value": {
+                    "kind": "Error",
+                    "ti": 1,
+                    "msg": "<not supported>"
+                }
+            },
+            {
+                "name": "__package__",
+                "value": {
+                    "kind": "Error",
+                    "ti": 1,
+                    "msg": "<not supported>"
+                }
+            },
+            {
+                "name": "__loader__",
+                "value": {
+                    "kind": "Error",
+                    "ti": 1,
+                    "msg": "<not supported>"
+                }
+            },
+            {
+                "name": "__spec__",
+                "value": {
+                    "kind": "Error",
+                    "ti": 1,
+                    "msg": "<not supported>"
+                }
+            },
+            {
+                "name": "__file__",
+                "value": {
+                    "kind": "Error",
+                    "ti": 1,
+                    "msg": "<not supported>"
+                }
+            },
+            {
+                "name": "__cached__",
+                "value": {
+                    "kind": "Error",
+                    "ti": 1,
+                    "msg": "<not supported>"
+                }
+            },
+            {
+                "name": "__builtins__",
+                "value": {
+                    "kind": "Error",
+                    "ti": 1,
+                    "msg": "<not supported>"
+                }
+            },
+            {
+                "name": "foo",
+                "value": {
+                    "kind": "Error",
+                    "ti": 1,
+                    "msg": "<not supported>"
+                }
+            }
+        ]
+    ],
+    "types": [
+        {
+            "kind": 7,
+            "lang_type": "int"
+        },
+        {
+            "kind": 30,
+            "lang_type": "<no type>"
+        }
+    ],
+    "events": [],
+    "paths": [
+        "",
+        "/workspace/codetracer-python-recorder/tests/programs/calc.py"
+    ]
+}

--- a/tests/programs/calc.py
+++ b/tests/programs/calc.py
@@ -1,0 +1,6 @@
+def foo():
+    x = 1
+    x += 1
+    return x
+
+foo()

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -1,0 +1,41 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TRACE_SCRIPT = REPO_ROOT / "src" / "trace.py"
+PROGRAMS_DIR = Path(__file__).parent / "programs"
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+class TraceTests(unittest.TestCase):
+    def test_program_traces(self):
+        for program in sorted(PROGRAMS_DIR.glob("*.py")):
+            with self.subTest(program=program.name):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    subprocess.run(
+                        [sys.executable, str(TRACE_SCRIPT), str(program)],
+                        cwd=tmpdir,
+                        check=True,
+                    )
+                    trace_file = Path(tmpdir) / "trace.json"
+                    self.assertTrue(trace_file.exists())
+                    with open(trace_file) as f:
+                        trace_data = json.load(f)
+                    trace_data.pop("workdir", None)
+                    fixture_path = FIXTURES_DIR / f"{program.stem}.json"
+                    self.assertTrue(
+                        fixture_path.exists(),
+                        msg=f"Missing fixture for {program.name}",
+                    )
+                    with open(fixture_path) as f:
+                        expected_data = json.load(f)
+                    expected_data.pop("workdir", None)
+                    self.assertEqual(trace_data, expected_data)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- capture variables for each step and restrict tracing to the target program
- allow specifying program path to trace
- move example program to `tests/programs`
- record a fixture trace and compare it in the test suite

## Testing
- `python -m unittest discover -v`