### PR TITLE
Fix nondeterministic ordering for object field values

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ python trace.py <path to python file>
 
 however you probably want to use it in combination with CodeTracer, which would be released soon.
 
+### Supported value types
+
+The tracer currently understands a subset of Python's built‑in types. It can
+record integers, booleans, strings, lists, floats, tuples, byte strings,
+complex numbers and simple objects (via ``__dict__`` introspection). Values that
+don't fall in these categories are stored as raw strings.
+
+Dictionary and set types are not yet handled.
+
 ## Future directions
 
 The current Python support is an unfinished prototype. We can finish it. In the future, it may be expanded to function in a way to similar to the more complete implementations, e.g. [Noir](https://github.com/blocksense-network/noir/tree/blocksense/tooling/tracer).

--- a/tests/fixtures/array_sum.json
+++ b/tests/fixtures/array_sum.json
@@ -45,6 +45,42 @@
     }
   },
   {
+    "Type": {
+      "kind": 8,
+      "lang_type": "Float",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
+    "Type": {
+      "kind": 27,
+      "lang_type": "Tuple",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
+    "Type": {
+      "kind": 16,
+      "lang_type": "Bytes",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
+    "Type": {
+      "kind": 6,
+      "lang_type": "Complex",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
     "Path": ""
   },
   {
@@ -111,7 +147,7 @@
       "variable_id": 0,
       "value": {
         "kind": "Sequence",
-        "type_id": 5,
+        "type_id": 9,
         "elements": [
           {
             "kind": "Int",
@@ -148,7 +184,7 @@
           "variable_id": 0,
           "value": {
             "kind": "Sequence",
-            "type_id": 5,
+            "type_id": 9,
             "elements": [
               {
                 "kind": "Int",
@@ -183,7 +219,7 @@
       "variable_id": 0,
       "value": {
         "kind": "Sequence",
-        "type_id": 5,
+        "type_id": 9,
         "elements": [
           {
             "kind": "Int",
@@ -216,7 +252,7 @@
       "variable_id": 0,
       "value": {
         "kind": "Sequence",
-        "type_id": 5,
+        "type_id": 9,
         "elements": [
           {
             "kind": "Int",
@@ -262,7 +298,7 @@
       "variable_id": 0,
       "value": {
         "kind": "Sequence",
-        "type_id": 5,
+        "type_id": 9,
         "elements": [
           {
             "kind": "Int",
@@ -318,7 +354,7 @@
       "variable_id": 0,
       "value": {
         "kind": "Sequence",
-        "type_id": 5,
+        "type_id": 9,
         "elements": [
           {
             "kind": "Int",
@@ -371,7 +407,7 @@
       "variable_id": 0,
       "value": {
         "kind": "Sequence",
-        "type_id": 5,
+        "type_id": 9,
         "elements": [
           {
             "kind": "Int",
@@ -424,7 +460,7 @@
       "variable_id": 0,
       "value": {
         "kind": "Sequence",
-        "type_id": 5,
+        "type_id": 9,
         "elements": [
           {
             "kind": "Int",
@@ -477,7 +513,7 @@
       "variable_id": 0,
       "value": {
         "kind": "Sequence",
-        "type_id": 5,
+        "type_id": 9,
         "elements": [
           {
             "kind": "Int",
@@ -530,7 +566,7 @@
       "variable_id": 0,
       "value": {
         "kind": "Sequence",
-        "type_id": 5,
+        "type_id": 9,
         "elements": [
           {
             "kind": "Int",
@@ -583,7 +619,7 @@
       "variable_id": 0,
       "value": {
         "kind": "Sequence",
-        "type_id": 5,
+        "type_id": 9,
         "elements": [
           {
             "kind": "Int",
@@ -636,7 +672,7 @@
       "variable_id": 0,
       "value": {
         "kind": "Sequence",
-        "type_id": 5,
+        "type_id": 9,
         "elements": [
           {
             "kind": "Int",
@@ -718,7 +754,7 @@
       "variable_id": 0,
       "value": {
         "kind": "Sequence",
-        "type_id": 5,
+        "type_id": 9,
         "elements": [
           {
             "kind": "Int",

--- a/tests/fixtures/calc.json
+++ b/tests/fixtures/calc.json
@@ -45,6 +45,42 @@
     }
   },
   {
+    "Type": {
+      "kind": 8,
+      "lang_type": "Float",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
+    "Type": {
+      "kind": 27,
+      "lang_type": "Tuple",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
+    "Type": {
+      "kind": 16,
+      "lang_type": "Bytes",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
+    "Type": {
+      "kind": 6,
+      "lang_type": "Complex",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
     "Path": ""
   },
   {

--- a/tests/fixtures/new_types.json
+++ b/tests/fixtures/new_types.json
@@ -1,0 +1,1150 @@
+[
+  {
+    "Type": {
+      "kind": 7,
+      "lang_type": "Integer",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
+    "Type": {
+      "kind": 9,
+      "lang_type": "String",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
+    "Type": {
+      "kind": 12,
+      "lang_type": "Bool",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
+    "Type": {
+      "kind": 9,
+      "lang_type": "Symbol",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
+    "Type": {
+      "kind": 24,
+      "lang_type": "No type",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
+    "Type": {
+      "kind": 8,
+      "lang_type": "Float",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
+    "Type": {
+      "kind": 27,
+      "lang_type": "Tuple",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
+    "Type": {
+      "kind": 16,
+      "lang_type": "Bytes",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
+    "Type": {
+      "kind": 6,
+      "lang_type": "Complex",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
+    "Path": ""
+  },
+  {
+    "Function": {
+      "path_id": 0,
+      "line": 1,
+      "name": "<top-level>"
+    }
+  },
+  {
+    "Call": {
+      "function_id": 0,
+      "args": []
+    }
+  },
+  {
+    "Path": "new_types.py"
+  },
+  {
+    "Function": {
+      "path_id": 1,
+      "line": 1,
+      "name": "<module>"
+    }
+  },
+  {
+    "Call": {
+      "function_id": 1,
+      "args": []
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 1
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 14
+    }
+  },
+  {
+    "Function": {
+      "path_id": 1,
+      "line": 1,
+      "name": "demo"
+    }
+  },
+  {
+    "Call": {
+      "function_id": 2,
+      "args": []
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 2
+    }
+  },
+  {
+    "Function": {
+      "path_id": 1,
+      "line": 2,
+      "name": "MyObj"
+    }
+  },
+  {
+    "Call": {
+      "function_id": 3,
+      "args": []
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 2
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 3
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 3
+    }
+  },
+  {
+    "VariableName": "<return_value>"
+  },
+  {
+    "Value": {
+      "variable_id": 0,
+      "value": {
+        "kind": "None",
+        "type_id": 4
+      }
+    }
+  },
+  {
+    "Return": {
+      "return_value": {
+        "kind": "None",
+        "type_id": 4
+      }
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 7
+    }
+  },
+  {
+    "VariableName": "MyObj"
+  },
+  {
+    "Type": {
+      "kind": 6,
+      "lang_type": "type",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
+    "Type": {
+      "kind": 16,
+      "lang_type": "Object",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
+    "Type": {
+      "kind": 6,
+      "lang_type": "function",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 1,
+      "value": {
+        "kind": "Struct",
+        "type_id": 9,
+        "field_values": [
+          {
+            "kind": "Raw",
+            "type_id": 10,
+            "r": "<attribute '__dict__' of 'MyObj' objects>"
+          },
+          {
+            "kind": "None",
+            "type_id": 4
+          },
+          {
+            "kind": "Struct",
+            "type_id": 11,
+            "field_values": []
+          },
+          {
+            "kind": "String",
+            "type_id": 1,
+            "text": "__main__"
+          },
+          {
+            "kind": "Raw",
+            "type_id": 10,
+            "r": "<attribute '__weakref__' of 'MyObj' objects>"
+          }
+        ]
+      }
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 8
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 1,
+      "value": {
+        "kind": "Struct",
+        "type_id": 9,
+        "field_values": [
+          {
+            "kind": "Raw",
+            "type_id": 10,
+            "r": "<attribute '__dict__' of 'MyObj' objects>"
+          },
+          {
+            "kind": "None",
+            "type_id": 4
+          },
+          {
+            "kind": "Struct",
+            "type_id": 11,
+            "field_values": []
+          },
+          {
+            "kind": "String",
+            "type_id": 1,
+            "text": "__main__"
+          },
+          {
+            "kind": "Raw",
+            "type_id": 10,
+            "r": "<attribute '__weakref__' of 'MyObj' objects>"
+          }
+        ]
+      }
+    }
+  },
+  {
+    "VariableName": "fl"
+  },
+  {
+    "Value": {
+      "variable_id": 2,
+      "value": {
+        "kind": "Float",
+        "type_id": 5,
+        "f": 1.5
+      }
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 9
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 1,
+      "value": {
+        "kind": "Struct",
+        "type_id": 9,
+        "field_values": [
+          {
+            "kind": "Raw",
+            "type_id": 10,
+            "r": "<attribute '__dict__' of 'MyObj' objects>"
+          },
+          {
+            "kind": "None",
+            "type_id": 4
+          },
+          {
+            "kind": "Struct",
+            "type_id": 11,
+            "field_values": []
+          },
+          {
+            "kind": "String",
+            "type_id": 1,
+            "text": "__main__"
+          },
+          {
+            "kind": "Raw",
+            "type_id": 10,
+            "r": "<attribute '__weakref__' of 'MyObj' objects>"
+          }
+        ]
+      }
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 2,
+      "value": {
+        "kind": "Float",
+        "type_id": 5,
+        "f": 1.5
+      }
+    }
+  },
+  {
+    "VariableName": "tpl"
+  },
+  {
+    "Value": {
+      "variable_id": 3,
+      "value": {
+        "kind": "Tuple",
+        "type_id": 6,
+        "elements": [
+          {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 1
+          },
+          {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 2
+          },
+          {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 3
+          }
+        ]
+      }
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 10
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 1,
+      "value": {
+        "kind": "Struct",
+        "type_id": 9,
+        "field_values": [
+          {
+            "kind": "Raw",
+            "type_id": 10,
+            "r": "<attribute '__dict__' of 'MyObj' objects>"
+          },
+          {
+            "kind": "None",
+            "type_id": 4
+          },
+          {
+            "kind": "Struct",
+            "type_id": 11,
+            "field_values": []
+          },
+          {
+            "kind": "String",
+            "type_id": 1,
+            "text": "__main__"
+          },
+          {
+            "kind": "Raw",
+            "type_id": 10,
+            "r": "<attribute '__weakref__' of 'MyObj' objects>"
+          }
+        ]
+      }
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 2,
+      "value": {
+        "kind": "Float",
+        "type_id": 5,
+        "f": 1.5
+      }
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 3,
+      "value": {
+        "kind": "Tuple",
+        "type_id": 6,
+        "elements": [
+          {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 1
+          },
+          {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 2
+          },
+          {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 3
+          }
+        ]
+      }
+    }
+  },
+  {
+    "VariableName": "bb"
+  },
+  {
+    "Value": {
+      "variable_id": 4,
+      "value": {
+        "kind": "Raw",
+        "type_id": 7,
+        "r": "b'xy'"
+      }
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 11
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 1,
+      "value": {
+        "kind": "Struct",
+        "type_id": 9,
+        "field_values": [
+          {
+            "kind": "Raw",
+            "type_id": 10,
+            "r": "<attribute '__dict__' of 'MyObj' objects>"
+          },
+          {
+            "kind": "None",
+            "type_id": 4
+          },
+          {
+            "kind": "Struct",
+            "type_id": 11,
+            "field_values": []
+          },
+          {
+            "kind": "String",
+            "type_id": 1,
+            "text": "__main__"
+          },
+          {
+            "kind": "Raw",
+            "type_id": 10,
+            "r": "<attribute '__weakref__' of 'MyObj' objects>"
+          }
+        ]
+      }
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 2,
+      "value": {
+        "kind": "Float",
+        "type_id": 5,
+        "f": 1.5
+      }
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 3,
+      "value": {
+        "kind": "Tuple",
+        "type_id": 6,
+        "elements": [
+          {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 1
+          },
+          {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 2
+          },
+          {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 3
+          }
+        ]
+      }
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 4,
+      "value": {
+        "kind": "Raw",
+        "type_id": 7,
+        "r": "b'xy'"
+      }
+    }
+  },
+  {
+    "VariableName": "cmplx"
+  },
+  {
+    "Value": {
+      "variable_id": 5,
+      "value": {
+        "kind": "Struct",
+        "type_id": 8,
+        "field_values": [
+          {
+            "kind": "Float",
+            "type_id": 5,
+            "f": 1.0
+          },
+          {
+            "kind": "Float",
+            "type_id": 5,
+            "f": 2.0
+          }
+        ]
+      }
+    }
+  },
+  {
+    "Function": {
+      "path_id": 1,
+      "line": 3,
+      "name": "__init__"
+    }
+  },
+  {
+    "VariableName": "self"
+  },
+  {
+    "Type": {
+      "kind": 6,
+      "lang_type": "MyObj",
+      "specific_info": {
+        "kind": "None"
+      }
+    }
+  },
+  {
+    "Call": {
+      "function_id": 4,
+      "args": [
+        {
+          "variable_id": 6,
+          "value": {
+            "kind": "Struct",
+            "type_id": 12,
+            "field_values": []
+          }
+        }
+      ]
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 4
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 6,
+      "value": {
+        "kind": "Struct",
+        "type_id": 12,
+        "field_values": []
+      }
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 5
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 6,
+      "value": {
+        "kind": "Struct",
+        "type_id": 12,
+        "field_values": [
+          {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 10
+          }
+        ]
+      }
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 5
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 6,
+      "value": {
+        "kind": "Struct",
+        "type_id": 12,
+        "field_values": [
+          {
+            "kind": "String",
+            "type_id": 1,
+            "text": "hi"
+          },
+          {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 10
+          }
+        ]
+      }
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 0,
+      "value": {
+        "kind": "None",
+        "type_id": 4
+      }
+    }
+  },
+  {
+    "Return": {
+      "return_value": {
+        "kind": "None",
+        "type_id": 4
+      }
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 12
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 1,
+      "value": {
+        "kind": "Struct",
+        "type_id": 9,
+        "field_values": [
+          {
+            "kind": "Raw",
+            "type_id": 10,
+            "r": "<attribute '__dict__' of 'MyObj' objects>"
+          },
+          {
+            "kind": "None",
+            "type_id": 4
+          },
+          {
+            "kind": "Struct",
+            "type_id": 11,
+            "field_values": []
+          },
+          {
+            "kind": "String",
+            "type_id": 1,
+            "text": "__main__"
+          },
+          {
+            "kind": "Raw",
+            "type_id": 10,
+            "r": "<attribute '__weakref__' of 'MyObj' objects>"
+          }
+        ]
+      }
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 2,
+      "value": {
+        "kind": "Float",
+        "type_id": 5,
+        "f": 1.5
+      }
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 3,
+      "value": {
+        "kind": "Tuple",
+        "type_id": 6,
+        "elements": [
+          {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 1
+          },
+          {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 2
+          },
+          {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 3
+          }
+        ]
+      }
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 4,
+      "value": {
+        "kind": "Raw",
+        "type_id": 7,
+        "r": "b'xy'"
+      }
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 5,
+      "value": {
+        "kind": "Struct",
+        "type_id": 8,
+        "field_values": [
+          {
+            "kind": "Float",
+            "type_id": 5,
+            "f": 1.0
+          },
+          {
+            "kind": "Float",
+            "type_id": 5,
+            "f": 2.0
+          }
+        ]
+      }
+    }
+  },
+  {
+    "VariableName": "obj"
+  },
+  {
+    "Value": {
+      "variable_id": 7,
+      "value": {
+        "kind": "Struct",
+        "type_id": 12,
+        "field_values": [
+          {
+            "kind": "String",
+            "type_id": 1,
+            "text": "hi"
+          },
+          {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 10
+          }
+        ]
+      }
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 12
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 1,
+      "value": {
+        "kind": "Struct",
+        "type_id": 9,
+        "field_values": [
+          {
+            "kind": "Raw",
+            "type_id": 10,
+            "r": "<attribute '__dict__' of 'MyObj' objects>"
+          },
+          {
+            "kind": "None",
+            "type_id": 4
+          },
+          {
+            "kind": "Struct",
+            "type_id": 11,
+            "field_values": []
+          },
+          {
+            "kind": "String",
+            "type_id": 1,
+            "text": "__main__"
+          },
+          {
+            "kind": "Raw",
+            "type_id": 10,
+            "r": "<attribute '__weakref__' of 'MyObj' objects>"
+          }
+        ]
+      }
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 2,
+      "value": {
+        "kind": "Float",
+        "type_id": 5,
+        "f": 1.5
+      }
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 3,
+      "value": {
+        "kind": "Tuple",
+        "type_id": 6,
+        "elements": [
+          {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 1
+          },
+          {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 2
+          },
+          {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 3
+          }
+        ]
+      }
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 4,
+      "value": {
+        "kind": "Raw",
+        "type_id": 7,
+        "r": "b'xy'"
+      }
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 5,
+      "value": {
+        "kind": "Struct",
+        "type_id": 8,
+        "field_values": [
+          {
+            "kind": "Float",
+            "type_id": 5,
+            "f": 1.0
+          },
+          {
+            "kind": "Float",
+            "type_id": 5,
+            "f": 2.0
+          }
+        ]
+      }
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 7,
+      "value": {
+        "kind": "Struct",
+        "type_id": 12,
+        "field_values": [
+          {
+            "kind": "String",
+            "type_id": 1,
+            "text": "hi"
+          },
+          {
+            "kind": "Int",
+            "type_id": 0,
+            "i": 10
+          }
+        ]
+      }
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 0,
+      "value": {
+        "kind": "Tuple",
+        "type_id": 6,
+        "elements": [
+          {
+            "kind": "Float",
+            "type_id": 5,
+            "f": 1.5
+          },
+          {
+            "kind": "Tuple",
+            "type_id": 6,
+            "elements": [
+              {
+                "kind": "Int",
+                "type_id": 0,
+                "i": 1
+              },
+              {
+                "kind": "Int",
+                "type_id": 0,
+                "i": 2
+              },
+              {
+                "kind": "Int",
+                "type_id": 0,
+                "i": 3
+              }
+            ]
+          },
+          {
+            "kind": "Raw",
+            "type_id": 7,
+            "r": "b'xy'"
+          },
+          {
+            "kind": "Struct",
+            "type_id": 8,
+            "field_values": [
+              {
+                "kind": "Float",
+                "type_id": 5,
+                "f": 1.0
+              },
+              {
+                "kind": "Float",
+                "type_id": 5,
+                "f": 2.0
+              }
+            ]
+          },
+          {
+            "kind": "Struct",
+            "type_id": 12,
+            "field_values": [
+              {
+                "kind": "String",
+                "type_id": 1,
+                "text": "hi"
+              },
+              {
+                "kind": "Int",
+                "type_id": 0,
+                "i": 10
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "Return": {
+      "return_value": {
+        "kind": "Tuple",
+        "type_id": 6,
+        "elements": [
+          {
+            "kind": "Float",
+            "type_id": 5,
+            "f": 1.5
+          },
+          {
+            "kind": "Tuple",
+            "type_id": 6,
+            "elements": [
+              {
+                "kind": "Int",
+                "type_id": 0,
+                "i": 1
+              },
+              {
+                "kind": "Int",
+                "type_id": 0,
+                "i": 2
+              },
+              {
+                "kind": "Int",
+                "type_id": 0,
+                "i": 3
+              }
+            ]
+          },
+          {
+            "kind": "Raw",
+            "type_id": 7,
+            "r": "b'xy'"
+          },
+          {
+            "kind": "Struct",
+            "type_id": 8,
+            "field_values": [
+              {
+                "kind": "Float",
+                "type_id": 5,
+                "f": 1.0
+              },
+              {
+                "kind": "Float",
+                "type_id": 5,
+                "f": 2.0
+              }
+            ]
+          },
+          {
+            "kind": "Struct",
+            "type_id": 12,
+            "field_values": [
+              {
+                "kind": "String",
+                "type_id": 1,
+                "text": "hi"
+              },
+              {
+                "kind": "Int",
+                "type_id": 0,
+                "i": 10
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "Step": {
+      "path_id": 1,
+      "line": 14
+    }
+  },
+  {
+    "Value": {
+      "variable_id": 0,
+      "value": {
+        "kind": "None",
+        "type_id": 4
+      }
+    }
+  },
+  {
+    "Return": {
+      "return_value": {
+        "kind": "None",
+        "type_id": 4
+      }
+    }
+  }
+]

--- a/tests/programs/new_types.py
+++ b/tests/programs/new_types.py
@@ -1,0 +1,14 @@
+def demo():
+    class MyObj:
+        def __init__(self):
+            self.x = 10
+            self.msg = "hi"
+
+    fl = 1.5
+    tpl = (1, 2, 3)
+    bb = b'xy'
+    cmplx = 1 + 2j
+    obj = MyObj()
+    return fl, tpl, bb, cmplx, obj
+
+demo()


### PR DESCRIPTION
## Summary
- ensure `Tracer._value` sorts object field names when serializing `__dict__`
- update `new_types.json` fixture with deterministic order

## Testing
- `make test`
