### PR TITLE
Add packaging setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,21 @@ An unfinished prototype of a recorder of Python programs that produces [CodeTrac
 
 ### Usage
 
-you can currently use it directly with
+Install the package with `pip` or `uv`:
+
+```bash
+pip install codetracer-python-recorder
+```
+
+Then invoke the recorder as a command line tool:
+
+```bash
+codetracer-record <path to python file>
+# produces several trace json files in the current directory
+# or in the folder of `$CODETRACER_DB_TRACE_PATH` if such an env var is defined
+```
+
+During development you can also run it directly with
 
 ```bash
 python trace.py <path to python file>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "codetracer-python-recorder"
+version = "0.1.0"
+description = "Prototype recorder of Python programs producing CodeTracer traces"
+authors = [{name = "Metacraft Labs Ltd"}]
+license = {text = "MIT"}
+readme = "README.md"
+requires-python = ">=3.8"
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+]
+
+[tool.setuptools]
+py-modules = ["trace"]
+package-dir = {"" = "src"}
+
+[project.scripts]
+codetracer-record = "trace:main"

--- a/src/trace.py
+++ b/src/trace.py
@@ -200,17 +200,26 @@ def trace_program(program: str) -> Tracer:
     return tracer
 
 
-if __name__ == "__main__":
-    if len(sys.argv) < 2:
-        raise SystemExit("Usage: trace.py <program.py>")
+def main(argv: List[str] | None = None) -> None:
+    """Entry point for the command line interface."""
 
-    program_path = sys.argv[1]
+    if argv is None:
+        argv = sys.argv[1:]
+
+    if len(argv) < 1:
+        raise SystemExit("Usage: codetracer-record <program.py>")
+
+    program_path = argv[0]
     tracer = trace_program(program_path)
 
-    meta = {"workdir": os.getcwd(), "program": sys.argv[0], "args": sys.argv[1:]}
+    meta = {"workdir": os.getcwd(), "program": sys.argv[0], "args": argv}
     with open("trace_metadata.json", "w") as f:
         json.dump(meta, f, indent=2)
     with open("trace_paths.json", "w") as f:
         json.dump(tracer.paths, f, indent=2)
     with open("trace.json", "w") as f:
         json.dump(tracer.events, f, indent=2)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI passthrough
+    main()

--- a/src/trace.py
+++ b/src/trace.py
@@ -203,9 +203,6 @@ def trace_program(program: str) -> Tracer:
 def main(argv: List[str] | None = None) -> None:
     """Entry point for the command line interface."""
 
-    if argv is None:
-        argv = sys.argv[1:]
-
     if len(argv) < 1:
         raise SystemExit("Usage: codetracer-record <program.py>")
 
@@ -222,4 +219,4 @@ def main(argv: List[str] | None = None) -> None:
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI passthrough
-    main()
+    main(sys.argv[1:])


### PR DESCRIPTION
## Summary
- add `pyproject.toml` for setuptools packaging
- expose `codetracer-record` CLI via `trace:main`
- document package installation in README

## Testing
- `make test`