### PR TITLE
ci: Run CI for stacked PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: ['**']
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   nix-tests:


### PR DESCRIPTION
I'll use stacked PRs in order to make reviewing possible while still not getting blocked by waiting for an approval from a reviewer. To get this working the CI must run on PRs to other branches in addition to main