### PR TITLE
CodeObject wrapper and global CodeObject registry

### DIFF
--- a/.agents/tasks/2025/08/21-0939-codetype-interface
+++ b/.agents/tasks/2025/08/21-0939-codetype-interface
@@ -1,0 +1,19 @@
+Implement an interface for the CodeType object.
+
+The Python Monitoring API passes a CodeObject to each event handler. In the current implemenation of our Tracer trait the event handlers have an argument `_code: &Bound<'_, PyAny>` which gives
+access to this object. This is not a good interface because the type is too generic. PyO3 has a PyCodeObject type, however it doesn't expose any public members because the type is unstable,
+so we cannot use that one.
+
+We need to create our own type CodeObjectWrapper which can simplify access to the underlying code object type. Then we should use this type in the signature of the methods in the Tracer trait.
+The type should allow easy access to that functionality of the underlying code object which we will need to implement a recorder for a time-travel debugger. 
+On the other hand it is important not to introduce any performance problems. Some ideas to think about:
+- Minimize the copying of values
+- Repeated computations on each event call could be memoized
+- Any other approach that minimizes the performance hit
+
+Propose a design of the CodeObjectWrapper type. Write the design in design-docs/code-object.md. Do not actually implement the type for now, I need to confirm the design first.
+
+Here's relevant information:
+* design-docs/design-001.md - shows how we write design documentation
+* https://docs.python.org/3/library/sys.monitoring.html - Documentation of the Python sys.montoring API
+* https://docs.python.org/3/reference/datamodel.html#code-objects - Description of Python Code Objects.

--- a/.agents/tasks/2025/08/21-0939-codetype-interface
+++ b/.agents/tasks/2025/08/21-0939-codetype-interface
@@ -38,3 +38,5 @@ Also please add usage examples to the design documentation
 Implement the CodeObjectWrapper as designed. Update the Tracer trait as well as the callback_xxx functions accordingly. Write a comprehensive unit tests for CodeObjectWrapper.
 --- FOLLOW UP TASK ---
 There is an issue in the current implementation. We don't use caching effectively, since we create a new CodeObjectWrapper at each callback_xxx call. We need a global cache, probably keyed by the code object id. Propose design changes and update the design documents. Don't implement the changes themselves before I approve them.
+--- FOLLOW UP TASK ---
+Implement the global code object registry.

--- a/.agents/tasks/2025/08/21-0939-codetype-interface
+++ b/.agents/tasks/2025/08/21-0939-codetype-interface
@@ -17,3 +17,20 @@ Here's relevant information:
 * design-docs/design-001.md - shows how we write design documentation
 * https://docs.python.org/3/library/sys.monitoring.html - Documentation of the Python sys.montoring API
 * https://docs.python.org/3/reference/datamodel.html#code-objects - Description of Python Code Objects.
+
+--- FOLLOW UP TASK ---
+Please address any inline comments on the diff, as well as any additional instructions below.
+
+According to the PyO3 documentation it is preferred to use  instead of Py<T>. Is it possible that the code object wrapper takes that into account? Here is relevant info:
+* https://pyo3.rs/v0.25.1/types.html
+* https://docs.rs/pyo3/0.25.1/pyo3/index.html
+
+Also please add usage examples to the design documentation
+--- FOLLOW UP TASK ---
+Please address any inline comments on the diff, as well as any additional instructions below.
+
+According to the PyO3 documentation it is preferred to use `Bound<'_, T>` instead of Py<T>. Is it possible that the code object wrapper takes that into account? Here is relevant info:
+* https://pyo3.rs/v0.25.1/types.html
+* https://docs.rs/pyo3/0.25.1/pyo3/index.html
+
+Also please add usage examples to the design documentation

--- a/.agents/tasks/2025/08/21-0939-codetype-interface
+++ b/.agents/tasks/2025/08/21-0939-codetype-interface
@@ -34,3 +34,5 @@ According to the PyO3 documentation it is preferred to use `Bound<'_, T>` instea
 * https://docs.rs/pyo3/0.25.1/pyo3/index.html
 
 Also please add usage examples to the design documentation
+--- FOLLOW UP TASK ---
+Implement the CodeObjectWrapper as designed. Update the Tracer trait as well as the callback_xxx functions accordingly. Write a comprehensive unit tests for CodeObjectWrapper.

--- a/.agents/tasks/2025/08/21-0939-codetype-interface
+++ b/.agents/tasks/2025/08/21-0939-codetype-interface
@@ -36,3 +36,5 @@ According to the PyO3 documentation it is preferred to use `Bound<'_, T>` instea
 Also please add usage examples to the design documentation
 --- FOLLOW UP TASK ---
 Implement the CodeObjectWrapper as designed. Update the Tracer trait as well as the callback_xxx functions accordingly. Write a comprehensive unit tests for CodeObjectWrapper.
+--- FOLLOW UP TASK ---
+There is an issue in the current implementation. We don't use caching effectively, since we create a new CodeObjectWrapper at each callback_xxx call. We need a global cache, probably keyed by the code object id. Propose design changes and update the design documents. Don't implement the changes themselves before I approve them.

--- a/codetracer-python-recorder/Cargo.lock
+++ b/codetracer-python-recorder/Cargo.lock
@@ -69,6 +69,7 @@ name = "codetracer-python-recorder"
 version = "0.1.0"
 dependencies = [
  "bitflags",
+ "once_cell",
  "pyo3",
  "runtime_tracing",
 ]

--- a/codetracer-python-recorder/Cargo.lock
+++ b/codetracer-python-recorder/Cargo.lock
@@ -69,9 +69,23 @@ name = "codetracer-python-recorder"
 version = "0.1.0"
 dependencies = [
  "bitflags",
+ "dashmap",
  "once_cell",
  "pyo3",
  "runtime_tracing",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -100,6 +114,12 @@ dependencies = [
  "r-efi",
  "wasi",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "heck"
@@ -134,6 +154,16 @@ name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+
+[[package]]
+name = "lock_api"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -181,6 +211,19 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
 
 [[package]]
 name = "pkg-config"
@@ -281,6 +324,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "runtime_tracing"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,6 +356,12 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -355,6 +413,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
 name = "syn"
 version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -391,6 +455,70 @@ checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/codetracer-python-recorder/Cargo.toml
+++ b/codetracer-python-recorder/Cargo.toml
@@ -18,6 +18,7 @@ default = ["extension-module"]
 pyo3 = { version = "0.25.1" }
 runtime_tracing = "0.14.0"
 bitflags = "2.4"
+once_cell = "1.19"
 
 [dev-dependencies]
 pyo3 = { version = "0.25.1", features = ["auto-initialize"] }

--- a/codetracer-python-recorder/Cargo.toml
+++ b/codetracer-python-recorder/Cargo.toml
@@ -19,6 +19,7 @@ pyo3 = { version = "0.25.1" }
 runtime_tracing = "0.14.0"
 bitflags = "2.4"
 once_cell = "1.19"
+dashmap = "5.5"
 
 [dev-dependencies]
 pyo3 = { version = "0.25.1", features = ["auto-initialize"] }

--- a/codetracer-python-recorder/src/code_object.rs
+++ b/codetracer-python-recorder/src/code_object.rs
@@ -1,0 +1,130 @@
+use once_cell::sync::OnceCell;
+use pyo3::prelude::*;
+use pyo3::types::PyCode;
+
+/// A wrapper around Python `code` objects providing cached access to
+/// common attributes and line information.
+pub struct CodeObjectWrapper {
+    obj: Py<PyCode>,
+    id: usize,
+    cache: CodeObjectCache,
+}
+
+#[derive(Default)]
+struct CodeObjectCache {
+    filename: OnceCell<String>,
+    qualname: OnceCell<String>,
+    firstlineno: OnceCell<u32>,
+    argcount: OnceCell<u16>,
+    flags: OnceCell<u32>,
+    lines: OnceCell<Vec<LineEntry>>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LineEntry {
+    pub offset: u32,
+    pub line: u32,
+}
+
+impl CodeObjectWrapper {
+    /// Construct from a `CodeType` object. Computes `id` eagerly.
+    pub fn new(_py: Python<'_>, obj: &Bound<'_, PyCode>) -> Self {
+        let id = obj.as_ptr() as usize;
+        Self {
+            obj: obj.clone().unbind(),
+            id,
+            cache: CodeObjectCache::default(),
+        }
+    }
+
+    /// Borrow the owned `Py<PyCode>` as a `Bound<'py, PyCode>`.
+    pub fn as_bound<'py>(&'py self, py: Python<'py>) -> Bound<'py, PyCode> {
+        self.obj.bind(py).clone()
+    }
+
+    /// Return the stable identity of the code object (equivalent to `id(code)`).
+    pub fn id(&self) -> usize {
+        self.id
+    }
+
+    pub fn filename<'py>(&'py self, py: Python<'py>) -> PyResult<&'py str> {
+        let value = self.cache.filename.get_or_try_init(|| -> PyResult<String> {
+            let s: String = self
+                .as_bound(py)
+                .getattr("co_filename")?
+                .extract()?;
+            Ok(s)
+        })?;
+        Ok(value.as_str())
+    }
+
+    pub fn qualname<'py>(&'py self, py: Python<'py>) -> PyResult<&'py str> {
+        let value = self.cache.qualname.get_or_try_init(|| -> PyResult<String> {
+            let s: String = self
+                .as_bound(py)
+                .getattr("co_qualname")?
+                .extract()?;
+            Ok(s)
+        })?;
+        Ok(value.as_str())
+    }
+
+    pub fn first_line(&self, py: Python<'_>) -> PyResult<u32> {
+        let value = *self.cache.firstlineno.get_or_try_init(|| -> PyResult<u32> {
+            let v: u32 = self
+                .as_bound(py)
+                .getattr("co_firstlineno")?
+                .extract()?;
+            Ok(v)
+        })?;
+        Ok(value)
+    }
+
+    pub fn arg_count(&self, py: Python<'_>) -> PyResult<u16> {
+        let value = *self.cache.argcount.get_or_try_init(|| -> PyResult<u16> {
+            let v: u16 = self
+                .as_bound(py)
+                .getattr("co_argcount")?
+                .extract()?;
+            Ok(v)
+        })?;
+        Ok(value)
+    }
+
+    pub fn flags(&self, py: Python<'_>) -> PyResult<u32> {
+        let value = *self.cache.flags.get_or_try_init(|| -> PyResult<u32> {
+            let v: u32 = self
+                .as_bound(py)
+                .getattr("co_flags")?
+                .extract()?;
+            Ok(v)
+        })?;
+        Ok(value)
+    }
+
+    fn lines<'py>(&'py self, py: Python<'py>) -> PyResult<&'py [LineEntry]> {
+        let vec = self.cache.lines.get_or_try_init(|| -> PyResult<Vec<LineEntry>> {
+            let mut entries = Vec::new();
+            let iter = self.as_bound(py).call_method0("co_lines")?;
+            let iter = iter.try_iter()?;
+            for item in iter {
+                let (start, _end, line): (u32, u32, Option<u32>) = item?.extract()?;
+                if let Some(line) = line {
+                    entries.push(LineEntry { offset: start, line });
+                }
+            }
+            Ok(entries)
+        })?;
+        Ok(vec.as_slice())
+    }
+
+    /// Return the source line for a given instruction offset using a binary search.
+    pub fn line_for_offset(&self, py: Python<'_>, offset: u32) -> PyResult<Option<u32>> {
+        let lines = self.lines(py)?;
+        match lines.binary_search_by_key(&offset, |e| e.offset) {
+            Ok(idx) => Ok(Some(lines[idx].line)),
+            Err(0) => Ok(None),
+            Err(idx) => Ok(Some(lines[idx - 1].line)),
+        }
+    }
+}

--- a/codetracer-python-recorder/src/code_object.rs
+++ b/codetracer-python-recorder/src/code_object.rs
@@ -1,6 +1,8 @@
 use once_cell::sync::OnceCell;
 use pyo3::prelude::*;
 use pyo3::types::PyCode;
+use dashmap::DashMap;
+use std::sync::Arc;
 
 /// A wrapper around Python `code` objects providing cached access to
 /// common attributes and line information.
@@ -128,3 +130,35 @@ impl CodeObjectWrapper {
         }
     }
 }
+
+/// Global registry caching `CodeObjectWrapper` instances by code object id.
+#[derive(Default)]
+pub struct CodeObjectRegistry {
+    map: DashMap<usize, Arc<CodeObjectWrapper>>,
+}
+
+impl CodeObjectRegistry {
+    /// Retrieve the wrapper for `code`, inserting a new one if needed.
+    pub fn get_or_insert(
+        &self,
+        py: Python<'_>,
+        code: &Bound<'_, PyCode>,
+    ) -> Arc<CodeObjectWrapper> {
+        let id = code.as_ptr() as usize;
+        self.map
+            .entry(id)
+            .or_insert_with(|| Arc::new(CodeObjectWrapper::new(py, code)))
+            .clone() //AI? Why do we need to clone here?
+    }
+
+    /// Remove the wrapper for a given code id, if present.
+    pub fn remove(&self, id: usize) {
+        self.map.remove(&id);
+    }
+
+    /// Clear all cached wrappers.
+    pub fn clear(&self) {
+        self.map.clear();
+    }
+}
+

--- a/codetracer-python-recorder/src/code_object.rs
+++ b/codetracer-python-recorder/src/code_object.rs
@@ -38,8 +38,8 @@ impl CodeObjectWrapper {
     }
 
     /// Borrow the owned `Py<PyCode>` as a `Bound<'py, PyCode>`.
-    pub fn as_bound<'py>(&'py self, py: Python<'py>) -> Bound<'py, PyCode> {
-        self.obj.bind(py).clone()
+    pub fn as_bound<'py>(&'py self, py: Python<'py>) -> &Bound<'py, PyCode> {
+        self.obj.bind(py)
     }
 
     /// Return the stable identity of the code object (equivalent to `id(code)`).

--- a/codetracer-python-recorder/src/lib.rs
+++ b/codetracer-python-recorder/src/lib.rs
@@ -3,7 +3,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 
+pub mod code_object;
 pub mod tracer;
+pub use crate::code_object::CodeObjectWrapper;
 pub use crate::tracer::{install_tracer, uninstall_tracer, EventSet, Tracer};
 
 /// Global flag tracking whether tracing is active.

--- a/codetracer-python-recorder/src/lib.rs
+++ b/codetracer-python-recorder/src/lib.rs
@@ -5,7 +5,7 @@ use pyo3::prelude::*;
 
 pub mod code_object;
 pub mod tracer;
-pub use crate::code_object::CodeObjectWrapper;
+pub use crate::code_object::{CodeObjectRegistry, CodeObjectWrapper};
 pub use crate::tracer::{install_tracer, uninstall_tracer, EventSet, Tracer};
 
 /// Global flag tracking whether tracing is active.

--- a/codetracer-python-recorder/src/tracer.rs
+++ b/codetracer-python-recorder/src/tracer.rs
@@ -466,13 +466,12 @@ pub fn uninstall_tracer(py: Python<'_>) -> PyResult<()> {
 #[pyfunction]
 fn callback_call(
     py: Python<'_>,
-    code: Bound<'_, PyAny>,
+    code: Bound<'_, PyCode>,
     offset: i32,
     callable: Bound<'_, PyAny>,
     arg0: Option<Bound<'_, PyAny>>,
 ) -> PyResult<()> {
     if let Some(global) = GLOBAL.lock().unwrap().as_mut() {
-        let code = code.downcast::<PyCode>()?;
         let wrapper = CodeObjectWrapper::new(py, &code);
         global.tracer.on_call(py, &wrapper, offset, &callable, arg0.as_ref());
     }
@@ -480,9 +479,8 @@ fn callback_call(
 }
 
 #[pyfunction]
-fn callback_line(py: Python<'_>, code: Bound<'_, PyAny>, lineno: u32) -> PyResult<()> {
+fn callback_line(py: Python<'_>, code: Bound<'_, PyCode>, lineno: u32) -> PyResult<()> {
     if let Some(global) = GLOBAL.lock().unwrap().as_mut() {
-        let code = code.downcast::<PyCode>()?;
         let wrapper = CodeObjectWrapper::new(py, &code);
         global.tracer.on_line(py, &wrapper, lineno);
     }
@@ -490,9 +488,8 @@ fn callback_line(py: Python<'_>, code: Bound<'_, PyAny>, lineno: u32) -> PyResul
 }
 
 #[pyfunction]
-fn callback_instruction(py: Python<'_>, code: Bound<'_, PyAny>, instruction_offset: i32) -> PyResult<()> {
+fn callback_instruction(py: Python<'_>, code: Bound<'_, PyCode>, instruction_offset: i32) -> PyResult<()> {
     if let Some(global) = GLOBAL.lock().unwrap().as_mut() {
-        let code = code.downcast::<PyCode>()?;
         let wrapper = CodeObjectWrapper::new(py, &code);
         global.tracer.on_instruction(py, &wrapper, instruction_offset);
     }
@@ -502,12 +499,11 @@ fn callback_instruction(py: Python<'_>, code: Bound<'_, PyAny>, instruction_offs
 #[pyfunction]
 fn callback_jump(
     py: Python<'_>,
-    code: Bound<'_, PyAny>,
+    code: Bound<'_, PyCode>,
     instruction_offset: i32,
     destination_offset: i32,
 ) -> PyResult<()> {
     if let Some(global) = GLOBAL.lock().unwrap().as_mut() {
-        let code = code.downcast::<PyCode>()?;
         let wrapper = CodeObjectWrapper::new(py, &code);
         global
             .tracer
@@ -519,12 +515,11 @@ fn callback_jump(
 #[pyfunction]
 fn callback_branch(
     py: Python<'_>,
-    code: Bound<'_, PyAny>,
+    code: Bound<'_, PyCode>,
     instruction_offset: i32,
     destination_offset: i32,
 ) -> PyResult<()> {
     if let Some(global) = GLOBAL.lock().unwrap().as_mut() {
-        let code = code.downcast::<PyCode>()?;
         let wrapper = CodeObjectWrapper::new(py, &code);
         global
             .tracer
@@ -534,9 +529,8 @@ fn callback_branch(
 }
 
 #[pyfunction]
-fn callback_py_start(py: Python<'_>, code: Bound<'_, PyAny>, instruction_offset: i32) -> PyResult<()> {
+fn callback_py_start(py: Python<'_>, code: Bound<'_, PyCode>, instruction_offset: i32) -> PyResult<()> {
     if let Some(global) = GLOBAL.lock().unwrap().as_mut() {
-        let code = code.downcast::<PyCode>()?;
         let wrapper = CodeObjectWrapper::new(py, &code);
         global.tracer.on_py_start(py, &wrapper, instruction_offset);
     }
@@ -544,9 +538,8 @@ fn callback_py_start(py: Python<'_>, code: Bound<'_, PyAny>, instruction_offset:
 }
 
 #[pyfunction]
-fn callback_py_resume(py: Python<'_>, code: Bound<'_, PyAny>, instruction_offset: i32) -> PyResult<()> {
+fn callback_py_resume(py: Python<'_>, code: Bound<'_, PyCode>, instruction_offset: i32) -> PyResult<()> {
     if let Some(global) = GLOBAL.lock().unwrap().as_mut() {
-        let code = code.downcast::<PyCode>()?;
         let wrapper = CodeObjectWrapper::new(py, &code);
         global.tracer.on_py_resume(py, &wrapper, instruction_offset);
     }
@@ -556,12 +549,11 @@ fn callback_py_resume(py: Python<'_>, code: Bound<'_, PyAny>, instruction_offset
 #[pyfunction]
 fn callback_py_return(
     py: Python<'_>,
-    code: Bound<'_, PyAny>,
+    code: Bound<'_, PyCode>,
     instruction_offset: i32,
     retval: Bound<'_, PyAny>,
 ) -> PyResult<()> {
     if let Some(global) = GLOBAL.lock().unwrap().as_mut() {
-        let code = code.downcast::<PyCode>()?;
         let wrapper = CodeObjectWrapper::new(py, &code);
         global.tracer.on_py_return(py, &wrapper, instruction_offset, &retval);
     }
@@ -571,12 +563,11 @@ fn callback_py_return(
 #[pyfunction]
 fn callback_py_yield(
     py: Python<'_>,
-    code: Bound<'_, PyAny>,
+    code: Bound<'_, PyCode>,
     instruction_offset: i32,
     retval: Bound<'_, PyAny>,
 ) -> PyResult<()> {
     if let Some(global) = GLOBAL.lock().unwrap().as_mut() {
-        let code = code.downcast::<PyCode>()?;
         let wrapper = CodeObjectWrapper::new(py, &code);
         global.tracer.on_py_yield(py, &wrapper, instruction_offset, &retval);
     }
@@ -586,12 +577,11 @@ fn callback_py_yield(
 #[pyfunction]
 fn callback_py_throw(
     py: Python<'_>,
-    code: Bound<'_, PyAny>,
+    code: Bound<'_, PyCode>,
     instruction_offset: i32,
     exception: Bound<'_, PyAny>,
 ) -> PyResult<()> {
     if let Some(global) = GLOBAL.lock().unwrap().as_mut() {
-        let code = code.downcast::<PyCode>()?;
         let wrapper = CodeObjectWrapper::new(py, &code);
         global.tracer.on_py_throw(py, &wrapper, instruction_offset, &exception);
     }
@@ -601,12 +591,11 @@ fn callback_py_throw(
 #[pyfunction]
 fn callback_py_unwind(
     py: Python<'_>,
-    code: Bound<'_, PyAny>,
+    code: Bound<'_, PyCode>,
     instruction_offset: i32,
     exception: Bound<'_, PyAny>,
 ) -> PyResult<()> {
     if let Some(global) = GLOBAL.lock().unwrap().as_mut() {
-        let code = code.downcast::<PyCode>()?;
         let wrapper = CodeObjectWrapper::new(py, &code);
         global.tracer.on_py_unwind(py, &wrapper, instruction_offset, &exception);
     }
@@ -616,12 +605,11 @@ fn callback_py_unwind(
 #[pyfunction]
 fn callback_raise(
     py: Python<'_>,
-    code: Bound<'_, PyAny>,
+    code: Bound<'_, PyCode>,
     instruction_offset: i32,
     exception: Bound<'_, PyAny>,
 ) -> PyResult<()> {
     if let Some(global) = GLOBAL.lock().unwrap().as_mut() {
-        let code = code.downcast::<PyCode>()?;
         let wrapper = CodeObjectWrapper::new(py, &code);
         global.tracer.on_raise(py, &wrapper, instruction_offset, &exception);
     }
@@ -631,12 +619,11 @@ fn callback_raise(
 #[pyfunction]
 fn callback_reraise(
     py: Python<'_>,
-    code: Bound<'_, PyAny>,
+    code: Bound<'_, PyCode>,
     instruction_offset: i32,
     exception: Bound<'_, PyAny>,
 ) -> PyResult<()> {
     if let Some(global) = GLOBAL.lock().unwrap().as_mut() {
-        let code = code.downcast::<PyCode>()?;
         let wrapper = CodeObjectWrapper::new(py, &code);
         global.tracer.on_reraise(py, &wrapper, instruction_offset, &exception);
     }
@@ -646,12 +633,11 @@ fn callback_reraise(
 #[pyfunction]
 fn callback_exception_handled(
     py: Python<'_>,
-    code: Bound<'_, PyAny>,
+    code: Bound<'_, PyCode>,
     instruction_offset: i32,
     exception: Bound<'_, PyAny>,
 ) -> PyResult<()> {
     if let Some(global) = GLOBAL.lock().unwrap().as_mut() {
-        let code = code.downcast::<PyCode>()?;
         let wrapper = CodeObjectWrapper::new(py, &code);
         global
             .tracer
@@ -679,13 +665,12 @@ fn callback_exception_handled(
 #[pyfunction]
 fn callback_c_return(
     py: Python<'_>,
-    code: Bound<'_, PyAny>,
+    code: Bound<'_, PyCode>,
     offset: i32,
     callable: Bound<'_, PyAny>,
     arg0: Option<Bound<'_, PyAny>>,
 ) -> PyResult<()> {
     if let Some(global) = GLOBAL.lock().unwrap().as_mut() {
-        let code = code.downcast::<PyCode>()?;
         let wrapper = CodeObjectWrapper::new(py, &code);
         global
             .tracer
@@ -697,13 +682,12 @@ fn callback_c_return(
 #[pyfunction]
 fn callback_c_raise(
     py: Python<'_>,
-    code: Bound<'_, PyAny>,
+    code: Bound<'_, PyCode>,
     offset: i32,
     callable: Bound<'_, PyAny>,
     arg0: Option<Bound<'_, PyAny>>,
 ) -> PyResult<()> {
     if let Some(global) = GLOBAL.lock().unwrap().as_mut() {
-        let code = code.downcast::<PyCode>()?;
         let wrapper = CodeObjectWrapper::new(py, &code);
         global
             .tracer

--- a/codetracer-python-recorder/tests/code_object_wrapper.rs
+++ b/codetracer-python-recorder/tests/code_object_wrapper.rs
@@ -14,7 +14,6 @@ fn wrapper_basic_attributes() {
         let code: Bound<'_, PyCode> = func
             .getattr("__code__")
             .unwrap()
-            .clone()
             .downcast_into()
             .unwrap();
         let wrapper = CodeObjectWrapper::new(py, &code);
@@ -36,7 +35,6 @@ fn wrapper_line_for_offset() {
         let code: Bound<'_, PyCode> = func
             .getattr("__code__")
             .unwrap()
-            .clone()
             .downcast_into()
             .unwrap();
         let wrapper = CodeObjectWrapper::new(py, &code);

--- a/codetracer-python-recorder/tests/code_object_wrapper.rs
+++ b/codetracer-python-recorder/tests/code_object_wrapper.rs
@@ -1,0 +1,55 @@
+use codetracer_python_recorder::CodeObjectWrapper;
+use pyo3::prelude::*;
+use pyo3::types::{PyCode, PyModule};
+use std::ffi::CString;
+
+#[test]
+fn wrapper_basic_attributes() {
+    Python::with_gil(|py| {
+        let src = CString::new("def f(x):\n    return x + 1\n").unwrap();
+        let filename = CString::new("<string>").unwrap();
+        let module = CString::new("m").unwrap();
+        let m = PyModule::from_code(py, src.as_c_str(), filename.as_c_str(), module.as_c_str()).unwrap();
+        let func = m.getattr("f").unwrap();
+        let code: Bound<'_, PyCode> = func
+            .getattr("__code__")
+            .unwrap()
+            .clone()
+            .downcast_into()
+            .unwrap();
+        let wrapper = CodeObjectWrapper::new(py, &code);
+        assert_eq!(wrapper.arg_count(py).unwrap(), 1);
+        assert_eq!(wrapper.filename(py).unwrap(), "<string>");
+        assert_eq!(wrapper.qualname(py).unwrap(), "f");
+        assert!(wrapper.flags(py).unwrap() > 0);
+    });
+}
+
+#[test]
+fn wrapper_line_for_offset() {
+    Python::with_gil(|py| {
+        let src = CString::new("def g():\n    a = 1\n    b = 2\n    return a + b\n").unwrap();
+        let filename = CString::new("<string>").unwrap();
+        let module = CString::new("m2").unwrap();
+        let m = PyModule::from_code(py, src.as_c_str(), filename.as_c_str(), module.as_c_str()).unwrap();
+        let func = m.getattr("g").unwrap();
+        let code: Bound<'_, PyCode> = func
+            .getattr("__code__")
+            .unwrap()
+            .clone()
+            .downcast_into()
+            .unwrap();
+        let wrapper = CodeObjectWrapper::new(py, &code);
+        let lines = code.call_method0("co_lines").unwrap();
+        let iter = lines.try_iter().unwrap();
+        let mut last_line = None;
+        for item in iter {
+            let (start, _end, line): (u32, u32, Option<u32>) = item.unwrap().extract().unwrap();
+            if let Some(l) = line {
+                assert_eq!(wrapper.line_for_offset(py, start).unwrap(), Some(l));
+                last_line = Some(l);
+            }
+        }
+        assert_eq!(wrapper.line_for_offset(py, 10_000).unwrap(), last_line);
+    });
+}

--- a/codetracer-python-recorder/tests/code_object_wrapper.rs
+++ b/codetracer-python-recorder/tests/code_object_wrapper.rs
@@ -1,4 +1,4 @@
-use codetracer_python_recorder::CodeObjectWrapper;
+use codetracer_python_recorder::code_object::{CodeObjectWrapper, CodeObjectRegistry};
 use pyo3::prelude::*;
 use pyo3::types::{PyCode, PyModule};
 use std::ffi::CString;
@@ -49,5 +49,29 @@ fn wrapper_line_for_offset() {
             }
         }
         assert_eq!(wrapper.line_for_offset(py, 10_000).unwrap(), last_line);
+    });
+}
+
+#[test]
+fn registry_reuses_wrappers() {
+    Python::with_gil(|py| {
+        let src = CString::new("def h():\n    return 0\n").unwrap();
+        let filename = CString::new("<string>").unwrap();
+        let module = CString::new("m3").unwrap();
+        let m =
+            PyModule::from_code(py, src.as_c_str(), filename.as_c_str(), module.as_c_str())
+                .unwrap();
+        let func = m.getattr("h").unwrap();
+        let code: Bound<'_, PyCode> = func
+            .getattr("__code__")
+            .unwrap()
+            .clone()
+            .downcast_into()
+            .unwrap();
+        let registry = CodeObjectRegistry::default();
+        let w1 = registry.get_or_insert(py, &code);
+        let w2 = registry.get_or_insert(py, &code);
+        assert!(std::sync::Arc::ptr_eq(&w1, &w2));
+        registry.remove(w1.id());
     });
 }

--- a/design-docs/code-object.md
+++ b/design-docs/code-object.md
@@ -1,0 +1,85 @@
+# Code Object Wrapper Design
+
+## Overview
+
+The Python Monitoring API delivers a generic `CodeType` object to every tracing callback.  The current `Tracer` trait surfaces this object as `&Bound<'_, PyAny>`, forcing every implementation to perform attribute lookups and type conversions manually.  This document proposes a `CodeObjectWrapper` type that exposes a stable, typed interface to the underlying code object while minimizing per-event overhead.
+
+## Goals
+- Provide a strongly typed API for common `CodeType` attributes needed by tracers and recorders.
+- Ensure lookups are cheap by caching values and avoiding repeated Python attribute access.
+- Maintain a stable identity for each code object to correlate events across callbacks.
+- Avoid relying on the unstable `PyCodeObject` layout from the C API.
+
+## Non-Goals
+- Full re‑implementation of every `CodeType` attribute. Only the fields required for tracing and time‑travel debugging are exposed.
+- Direct mutation of `CodeType` objects. The wrapper offers read‑only access.
+
+## Proposed API
+
+```rs
+pub struct CodeObjectWrapper {
+    /// Strong reference to the Python `CodeType` object.
+    obj: Py<PyAny>,
+    /// Stable identity equivalent to `id(code)`.
+    id: usize,
+    /// Lazily populated cache for expensive lookups.
+    cache: CodeObjectCache,
+}
+
+pub struct CodeObjectCache {
+    filename: OnceCell<String>,
+    qualname: OnceCell<String>,
+    firstlineno: OnceCell<u32>,
+    argcount: OnceCell<u16>,
+    flags: OnceCell<u32>,
+    /// Mapping of instruction offsets to line numbers.
+    lines: OnceCell<Vec<LineEntry>>,
+}
+
+pub struct LineEntry {
+    pub offset: u32,
+    pub line: u32,
+}
+
+impl CodeObjectWrapper {
+    /// Construct from a generic Python object. Computes `id` eagerly.
+    pub fn new(py: Python<'_>, obj: &Bound<'_, PyAny>) -> Self;
+
+    /// Accessors fetch from the cache or perform a one‑time lookup under the GIL.
+    pub fn filename<'py>(&'py self, py: Python<'py>) -> PyResult<&'py str>;
+    pub fn qualname<'py>(&'py self, py: Python<'py>) -> PyResult<&'py str>;
+    pub fn first_line(&self, py: Python<'_>) -> PyResult<u32>;
+    pub fn arg_count(&self, py: Python<'_>) -> PyResult<u16>;
+    pub fn flags(&self, py: Python<'_>) -> PyResult<u32>;
+
+    /// Return the source line for a given instruction offset using a binary search on `lines`.
+    pub fn line_for_offset(&self, py: Python<'_>, offset: u32) -> PyResult<Option<u32>>;
+
+    /// Expose the stable identity for cross‑event correlation.
+    pub fn id(&self) -> usize;
+}
+```
+
+### Trait Integration
+
+The `Tracer` trait will be adjusted so every callback receives `&CodeObjectWrapper` instead of a generic `&Bound<'_, PyAny>`:
+
+```rs
+fn on_line(&mut self, py: Python<'_>, code: &CodeObjectWrapper, lineno: u32);
+fn on_py_start(&mut self, py: Python<'_>, code: &CodeObjectWrapper, offset: i32);
+// ...and similarly for the remaining callbacks.
+```
+
+## Performance Considerations
+- `Py<PyAny>` allows cloning the wrapper without holding the GIL, enabling cheap event propagation.
+- Fields are loaded lazily and stored inside `OnceCell` containers to avoid repeated attribute lookups.
+- `line_for_offset` memoizes the full line table the first time it is requested; subsequent calls perform an in‑memory binary search.
+- Storing strings and small integers directly in the cache eliminates conversion cost on hot paths.
+
+## Open Questions
+- Additional attributes such as `co_consts` or `co_varnames` may be required for richer debugging features; these can be added later as new `OnceCell` fields.
+- Thread‑safety requirements may necessitate wrapping the cache in `UnsafeCell` or providing internal mutability strategies compatible with `Send`/`Sync`.
+
+## References
+- [Python `CodeType` objects](https://docs.python.org/3/reference/datamodel.html#code-objects)
+- [Python monitoring API](https://docs.python.org/3/library/sys.monitoring.html)


### PR DESCRIPTION
Every event callback receives a _code argument which is of the Python type CodeObject. We created a CodeObjectWrapper type which wraps this object for two purposes:

1. To expose an easier to use interface which would focus on what we need to implement a tracer
2. To minimize performance hit by caching the code object data that we fetch from the Python object.

A code object corresponds to the body of a function or a module. With our wrapper and registry we guarantee that each code object is processed at most once.