### PR TITLE
feat: capture visible variables on line events

### DIFF
--- a/.agents/tasks/2025/08/21-0939-codetype-interface
+++ b/.agents/tasks/2025/08/21-0939-codetype-interface
@@ -98,3 +98,216 @@ diff --git a/None b/design-docs/workflow-platform-spec.md
 Please address any inline comments on the diff, as well as any additional instructions below.
 
 Now write a PR/FAQ document for this product. If there are important questions whose answers are unclear add them to the FAQ but don't write an answer 
+--- FOLLOW UP TASK ---
+Implement full variable capture in codetracer-python-recorder. Add a comprehensive test suite. Here is the spec for the task and the tests:
+
+Python Tracing Recorder: Capturing All Visible Variables at Each Line
+
+Overview of Python Variable Scopes
+
+In CPython, the accessible variables at a given execution point consist of:
+
+Local variables of the current function or code block (including parameters).
+
+Closure (nonlocal) variables that come from enclosing functions (if any).
+
+Global variables defined at the module level (the current module’s namespace).
+
+(Built-ins are also always accessible if not shadowed, but they are usually not included in “visible variables” snapshots for tracing.)
+
+
+Each executing frame in CPython carries these variables in its namespace. To capture a snapshot of all variables accessible at a line, we need to inspect the frame’s environment, combining locals, nonlocals, and globals. This must work for any code construct (functions, methods, comprehensions, class bodies, etc.) under CPython.
+
+Using the CPython C API (via PyO3) to Get Variables
+
+1. Access the current frame: The sys.monitoring API’s line event callback does not directly provide a frame object. We can obtain the current PyFrameObject via the C API. For example, using PyO3’s FFI, you can call PyThreadState_GetFrame(PyThreadState_Get()) to get a strong reference to the current frame object. (This yields the top-of-stack frame – if your callback is a C function, that should be the frame of the user code. If your callback is a Python function, you may need frame.f_back to get the user code’s frame.)
+
+2. Get all local and closure variables: Once you have the PyFrameObject *frame, retrieve the frame’s local variables mapping. In Python 3.12+, frame.f_locals is a proxy that reflects both local variables and any closure (cell/free) variables with their current values. In C, you can use PyFrame_GetLocals(frame) to get this mapping (as a proxy object). For a stable snapshot (independent copy), you can convert this to a real dictionary. One approach is calling the new API PyFrame_GetLocalsCopy(frame) (added with PEP 558) which returns a fresh dict of the frame’s locals at that moment. If that function isn’t directly accessible, you can manually create a dict and update it with the proxy (ensuring you capture values at that time).
+
+3. Get global variables: The frame’s globals are in frame.f_globals. You can obtain this dictionary via PyFrame_GetGlobals(frame). This is the module’s global namespace. For completeness, you may copy it to avoid future mutations, but since it’s a regular dict (not an optimized locals proxy), reading it directly is fine.
+
+4. Combine into a snapshot: The union of keys from the locals/closure snapshot and the globals dictionary constitutes all names accessible in that scope. In practice, you might present them separately (like debuggers do, showing locals vs. globals). But if needed, you can merge them (with locals overriding globals on name conflicts, as Python name resolution would). Each variable’s value can then be serialized or truncated as required.
+
+Important Details and Edge Cases
+
+Closure (free) variables: In modern CPython, closure variables are handled seamlessly via the frame’s locals proxy. You do not need to separately fetch function.__closure__ or outer frame variables – the frame’s local mapping already includes free vars. The PEP for frame proxies explicitly states that each access to frame.f_locals yields a mapping of local and closure variable names to their current values. This ensures that in a nested function, variables from an enclosing scope (nonlocals) appear in the inner frame’s locals mapping (bound to the value in the closure cell).
+
+Comprehensions and generators: In Python 3, list comprehensions, generator expressions, and the like are implemented as separate function frames. The above approach still works since those have their own frames (with any needed closure variables included similarly). Just grab that frame’s locals and globals as usual.
+
+Class bodies and module level: A class body or module top-level code is executed in an unoptimized frame where locals == globals (module) or a new class namespace dict. In these cases, frame.f_locals is a real dict of the namespace. Using PyFrame_GetLocalsCopy will still produce a snapshot of that dict. The global variables (for a class body, the “global” context is the module’s globals) are accessible via f_globals. So the method still enumerates everything correctly.
+
+Builtins: Typically, built-in names (from frame.f_builtins) are implicitly accessible if not shadowed, but they are usually not included in a variables snapshot. You can choose to ignore builtins unless needed, to avoid dumping a large static list each time.
+
+Name resolution order: If needed, CPython 3.12 introduced PyFrame_GetVar(frame, name) which will retrieve a variable by name as the interpreter would – checking locals (including cells), then globals, then builtins. This could be used to fetch specific variables on demand. However, for capturing all variables, it’s more efficient to pull the mappings as described above rather than querying names one by one.
+
+
+Putting It Together
+
+In your Rust/PyO3 tracing recorder, for each line event you can do something like:
+
+Get the current frame (frame_obj).
+
+Obtain a snapshot dict of locals (with closures) – e.g. via PyFrame_GetLocalsCopy(frame_obj) or by copying the proxy from frame.f_locals.
+
+Get the globals dict (globals_dict = PyFrame_GetGlobals(frame_obj)).
+
+Iterate over these mappings to collect name/value pairs. Apply your truncation to large objects as needed.
+
+Record or output this snapshot for the line.
+
+
+This approach will work for any Python code running on CPython. It leverages the official C-API designed for debuggers and monitoring tools, ensuring even tricky cases (like nonlocal variables, exec/eval contexts, etc.) are handled correctly. In Python 3.12+, the implementation of frame.f_locals and the new APIs from PEP 558/667 guarantee an up-to-date view of the frame’s environment, including cell/free variables.
+
+By using these facilities via PyO3, you can reliably capture all visible variables at each line of execution in your tracing recorder.
+
+References
+
+Python C-API – Frame Objects: functions to access frame attributes (locals, globals, etc.).
+
+PEP 667 – Frame locals proxy (Python 3.13): frame.f_locals now reflects local + cell + free variables’ values.
+
+PEP 558 – Defined semantics for locals(): introduced Py
+Locals_GetCopy/PyFrame_GetLocalsCopy to snapshot locals safely.
+
+Comprehensive Test Suite for Python Tracing Recorder
+
+This test suite is designed to verify that a tracing recorder (using sys.monitoring and frame inspection) correctly captures all variables visible at each executable line of Python code. Each test covers a distinct scope or visibility scenario in Python. The tracer should record every variable that is in scope at that line, ensuring no visible name is missed. We include functions, closures, globals, class scopes, comprehensions, generators, exception blocks, and more, to guarantee full coverage of Python's LEGB (Local, Enclosing, Global, Built-in) name resolution rules.
+
+Each test case below provides a brief description of what it covers, followed by a code snippet (Python script) that exercises that behavior. No actual tracing logic is included – we only show the source code whose execution should be monitored. The expectation is that at runtime, the tracer’s LINE event will fire on each line and the recorder will capture all variables accessible in that scope at that moment.
+
+1. Simple Function: Parameters and Locals
+
+Scope: This test focuses on a simple function with a parameter and local variables. It verifies that the recorder sees function parameters and any locals on each line inside the function. On entering the function, the parameter should be visible; as lines execute, newly assigned local variables become visible too. This ensures that basic function scope is handled.
+
+def simple_function(x):
+    a = 1                 # Parameter x is visible; local a is being defined
+    b = a + x             # Locals a, b and parameter x are visible (b defined this line)
+    return a, b           # Locals a, b and x still visible at return
+
+# Test the function
+result = simple_function(5)
+
+Expected: The tracer should capture x (parameter) and then a and b as they become defined in simple_function.
+
+2. Nested Functions and Closure Variables (nonlocal)
+
+Scope: This test covers nested functions, where an inner function uses a closure variable from its outer function. We verify that variables in the enclosing (nonlocal) scope are visible inside the inner function, and that the nonlocal statement allows the inner function to modify the outer variable. Both the outer function’s locals and the inner function’s locals (plus closed-over variables) should be captured appropriately.
+
+def outer_func(x):
+    y = 1
+    def inner_func(z):
+        nonlocal y            # Declare y from outer_func as nonlocal
+        w = x + y + z         # x (outer param), y (outer var), z (inner param), w (inner local)
+        y = w                 # Modify outer variable y
+        return w
+    total = inner_func(5)     # Calls inner_func, which updates y
+    return y, total           # y is updated in outer scope
+result = outer_func(2)
+
+Expected: Inside inner_func, the tracer should capture x, y (from outer scope), z, and w at each line. In outer_func, it should capture x, y, and later the returned total. This ensures enclosing scope variables are handled (nonlocal variables are accessible to nested functions).
+
+3. Global and Module-Level Variables
+
+Scope: This test validates visibility of module-level (global) variables. It defines globals and uses them inside a function, including modifying a global with the global statement. We ensure that at each line, global names are captured when in scope (either at the module level or when referenced inside a function).
+
+GLOBAL_VAL = 10
+counter = 0
+
+def global_test():
+    local_copy = GLOBAL_VAL       # Access a global variable
+    global counter
+    counter += 1                  # Modify a global variable
+    return local_copy, counter
+
+# Use the function and check global effects
+before = counter
+result = global_test()
+after = counter
+
+Expected: The tracer should capture GLOBAL_VAL and counter as globals on relevant lines. At the module level, GLOBAL_VAL, counter, before, after, etc. are in the global namespace. Inside global_test(), it should capture local_copy and see GLOBAL_VAL as a global. The global counter declaration ensures counter is treated as global in that function and its updated value remains in the module scope.
+
+4. Class Definition Scope and Metaclass
+
+Scope: This test targets class definition bodies, including the effect of a metaclass. When a class body executes, it has a local namespace that becomes the class’s attribute dictionary. We verify that variables assigned in the class body are captured, and that references to those variables or to globals are handled. Additionally, we include a metaclass to ensure that class creation via a metaclass is also traced.
+
+CONSTANT = 42
+
+class MetaCounter(type):
+    count = 0
+    def __init__(cls, name, bases, attrs):
+        MetaCounter.count += 1            # cls, name, bases, attrs visible; MetaCounter.count updated
+        super().__init__(name, bases, attrs)
+
+class Sample(metaclass=MetaCounter):
+    a = 10
+    b = a + 5                            # uses class attribute a
+    print(a, b, CONSTANT)               # can access class attrs a, b and global CONSTANT
+    def method(self):
+        return self.a + self.b
+
+# After class definition, metaclass count should have incremented
+instances = MetaCounter.count
+
+Expected: Within MetaCounter, the tracer should capture class-level attributes like count as well as method parameters (cls, name, bases, attrs) during class creation. In Sample’s body, it should capture a once defined, then b and a on the next line, and even allow access to CONSTANT (a global) during class body execution. After definition, Sample.a and Sample.b exist as class attributes (not directly as globals outside the class). The tracer should handle the class scope like a local namespace for that block.
+
+5. Lambdas and Comprehensions (List, Set, Dict, Generator)
+
+Scope: This combined test covers lambda expressions and various comprehensions, each of which introduces an inner scope. We ensure the tracer captures variables inside these expressions, including any outer variables they close over and the loop variables within comprehensions. Notably, in Python 3, the loop variable in a comprehension is local to the comprehension and not visible outside.
+
+Lambda: Tests an inline lambda function with its own parameter and expression.
+
+List Comprehension: Uses a loop variable internally and an external variable.
+
+Set & Dict Comprehensions: Similar scope behavior with their own loop variables.
+
+Generator Expression: A generator comprehension that lazily produces values.
+
+
+factor = 2
+double = lambda y: y * factor                      # 'y' is local parameter, 'factor' is captured from outer scope
+
+squares = [n**2 for n in range(3)]                 # 'n' is local to comprehension, not visible after6
+scaled_set = {n * factor for n in range(3)}        # set comprehension capturing outer 'factor'
+mapping = {n: n*factor for n in range(3)}          # dict comprehension with local n
+gen_exp = (n * factor for n in range(3))           # generator expression (lazy evaluated)
+result_list = list(gen_exp)                        # force generator to evaluate
+
+Expected: Inside the lambda, y (parameter) and factor (enclosing variable) are visible to the tracer. In each comprehension, the loop variable (e.g., n) and any outer variables (factor) should be captured during the comprehension's execution. After the comprehension, the loop variable is no longer defined (e.g., n is not accessible outside the list comprehension). The generator expression has a similar scope to a comprehension; its variables should be captured when it's iterated. All these ensure the recorder handles anonymous function scopes and comprehension internals.
+
+6. Generators and Coroutines (async/await)
+
+Scope: This test covers a generator function and an async coroutine function. Generators use yield to produce values and suspend execution, while async coroutines use await. We ensure that local variables persist across yields/awaits and remain visible when execution resumes (on each line hit). This verifies that the tracer captures the state in suspended functions.
+
+def counter_gen(n):
+    total = 0
+    for i in range(n):
+        total += i
+        yield total        # At yield: i and total are visible and persisted across resumes
+    return total
+
+import asyncio
+async def async_sum(data):
+    total = 0
+    for x in data:
+        total += x
+        await asyncio.sleep(0)   # At await: x and total persist in coroutine
+    return total
+
+# Run the generator
+gen = counter_gen(3)
+gen_results = list(gen)          # exhaust the generator
+
+# Run the async coroutine
+coroutine_result = asyncio.run(async_sum([1, 2, 3]))
+
+Expected: In counter_gen, at each yield line the tracer should capture i and total (and after resumption, those values are still available). In async_sum, at the await line, x and total are captured and remain after the await. The tracer must handle the resumption of these functions (triggered by PY_RESUME events) and still see previously defined locals. This test ensures generator state and coroutine state do not lose any variables between pauses.
+
+7. Try/Except/Finally and With Statement
+
+Scope: This test combines exception handling blocks and context manager usage. It verifies that the tracer captures variables introduced in a try/except flow (including the exception variable, which has a limited scope) as well as in a with statement context manager. We specifically ensure the exception alias is only visible inside the except block, and that variables from try, else, and finally blocks, as well as the with target, are all accounted for.
+
+def exception_and_with_demo(x):
+    try:
+        inv = 10 / x                       # In try: 'inv' defined if no error
+    except ZeroDivisionError as e:
+        error_msg = fError:

--- a/codetracer-python-recorder/Cargo.lock
+++ b/codetracer-python-recorder/Cargo.lock
@@ -134,6 +134,7 @@ dependencies = [
  "once_cell",
  "pyo3",
  "runtime_tracing",
+ "tempfile",
 ]
 
 [[package]]
@@ -183,6 +184,22 @@ dependencies = [
  "jiff",
  "log",
 ]
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fscommon"
@@ -274,6 +291,12 @@ name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lock_api"
@@ -516,6 +539,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -598,6 +634,19 @@ name = "target-lexicon"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
+
+[[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
 
 [[package]]
 name = "unicode-ident"

--- a/codetracer-python-recorder/Cargo.toml
+++ b/codetracer-python-recorder/Cargo.toml
@@ -25,3 +25,4 @@ env_logger = "0.11"
 
 [dev-dependencies]
 pyo3 = { version = "0.25.1", features = ["auto-initialize"] }
+tempfile = "3.10"

--- a/codetracer-python-recorder/src/runtime_tracer.rs
+++ b/codetracer-python-recorder/src/runtime_tracer.rs
@@ -1,10 +1,14 @@
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use pyo3::prelude::*;
-use pyo3::types::PyAny;
+use pyo3::types::{PyAny, PyDict, PyFrame, PyMapping};
+use pyo3::Py;
 
-use runtime_tracing::{Line, TraceEventsFileFormat, TraceWriter, TypeKind, ValueRecord, NONE_VALUE};
 use runtime_tracing::NonStreamingTraceWriter;
+use runtime_tracing::{
+    Line, TraceEventsFileFormat, TraceWriter, TypeKind, ValueRecord, NONE_VALUE,
+};
 
 use crate::code_object::CodeObjectWrapper;
 use crate::tracer::{events_union, EventSet, MonitoringEvents, Tracer};
@@ -50,10 +54,19 @@ impl RuntimeTracer {
     }
 
     /// Configure output files and write initial metadata records.
-    pub fn begin(&mut self, meta_path: &Path, paths_path: &Path, events_path: &Path, start_path: &Path, start_line: u32) -> PyResult<()> {
-        TraceWriter::begin_writing_trace_metadata(&mut self.writer, meta_path).map_err(to_py_err)?;
+    pub fn begin(
+        &mut self,
+        meta_path: &Path,
+        paths_path: &Path,
+        events_path: &Path,
+        start_path: &Path,
+        start_line: u32,
+    ) -> PyResult<()> {
+        TraceWriter::begin_writing_trace_metadata(&mut self.writer, meta_path)
+            .map_err(to_py_err)?;
         TraceWriter::begin_writing_trace_paths(&mut self.writer, paths_path).map_err(to_py_err)?;
-        TraceWriter::begin_writing_trace_events(&mut self.writer, events_path).map_err(to_py_err)?;
+        TraceWriter::begin_writing_trace_events(&mut self.writer, events_path)
+            .map_err(to_py_err)?;
         TraceWriter::start(&mut self.writer, start_path, Line(start_line as i64));
         Ok(())
     }
@@ -61,7 +74,9 @@ impl RuntimeTracer {
     /// Return true when tracing is active; may become true on first event
     /// from the activation file if configured.
     fn ensure_started<'py>(&mut self, py: Python<'py>, code: &CodeObjectWrapper) {
-        if self.started || self.activation_done { return; }
+        if self.started || self.activation_done {
+            return;
+        }
         if let Some(activation) = &self.activation_path {
             if let Ok(filename) = code.filename(py) {
                 let f = Path::new(filename);
@@ -71,7 +86,10 @@ impl RuntimeTracer {
                 if f == activation {
                     self.started = true;
                     self.activation_code_id = Some(code.id());
-                    log::debug!("[RuntimeTracer] activated on enter: {}", activation.display());
+                    log::debug!(
+                        "[RuntimeTracer] activated on enter: {}",
+                        activation.display()
+                    );
                 }
             }
         }
@@ -93,24 +111,373 @@ impl RuntimeTracer {
         }
         if let Ok(s) = v.extract::<String>() {
             let ty = TraceWriter::ensure_type_id(&mut self.writer, TypeKind::String, "String");
-            return ValueRecord::String { text: s, type_id: ty };
+            return ValueRecord::String {
+                text: s,
+                type_id: ty,
+            };
         }
 
         // Fallback to Raw string representation
         let ty = TraceWriter::ensure_type_id(&mut self.writer, TypeKind::Raw, "Object");
         match v.str() {
-            Ok(s) => ValueRecord::Raw { r: s.to_string_lossy().into_owned(), type_id: ty },
-            Err(_) => ValueRecord::Error { msg: "<unrepr>".to_string(), type_id: ty },
+            Ok(s) => ValueRecord::Raw {
+                r: s.to_string_lossy().into_owned(),
+                type_id: ty,
+            },
+            Err(_) => ValueRecord::Error {
+                msg: "<unrepr>".to_string(),
+                type_id: ty,
+            },
         }
     }
 
-    fn ensure_function_id(&mut self, py: Python<'_>, code: &CodeObjectWrapper) -> PyResult<runtime_tracing::FunctionId> {
+    fn ensure_function_id(
+        &mut self,
+        py: Python<'_>,
+        code: &CodeObjectWrapper,
+    ) -> PyResult<runtime_tracing::FunctionId> {
         //TODO AI! current runtime_tracer logic expects that `name` is unique and is used as a key for the function.
         //This is wrong. We need to write a test that exposes this issue
         let name = code.qualname(py)?;
         let filename = code.filename(py)?;
         let first_line = code.first_line(py)?;
-        Ok(TraceWriter::ensure_function_id(&mut self.writer, name, Path::new(filename), Line(first_line as i64)))
+        Ok(TraceWriter::ensure_function_id(
+            &mut self.writer,
+            name,
+            Path::new(filename),
+            Line(first_line as i64),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tracer::{install_tracer, uninstall_tracer, EventSet, MonitoringEvents, Tracer};
+    use pyo3::types::PyModule;
+    use runtime_tracing::{TraceEventsFileFormat, TraceLowLevelEvent};
+    use std::collections::{HashMap, HashSet};
+    use std::ffi::CString;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::sync::{Arc, Mutex};
+    use tempfile::tempdir;
+
+    struct SharedTracer {
+        inner: Arc<Mutex<RuntimeTracer>>,
+    }
+
+    impl Tracer for SharedTracer {
+        fn interest(&self, events: &MonitoringEvents) -> EventSet {
+            let guard = self.inner.lock().unwrap();
+            guard.interest(events)
+        }
+
+        fn on_py_start(&mut self, py: Python<'_>, code: &CodeObjectWrapper, offset: i32) {
+            let mut guard = self.inner.lock().unwrap();
+            guard.on_py_start(py, code, offset);
+        }
+
+        fn on_line(&mut self, py: Python<'_>, code: &CodeObjectWrapper, lineno: u32) {
+            let mut guard = self.inner.lock().unwrap();
+            guard.on_line(py, code, lineno);
+        }
+
+        fn on_py_return(
+            &mut self,
+            py: Python<'_>,
+            code: &CodeObjectWrapper,
+            offset: i32,
+            retval: &Bound<'_, PyAny>,
+        ) {
+            let mut guard = self.inner.lock().unwrap();
+            guard.on_py_return(py, code, offset, retval);
+        }
+
+        fn flush(&mut self, py: Python<'_>) -> PyResult<()> {
+            let mut guard = self.inner.lock().unwrap();
+            guard.flush(py)
+        }
+
+        fn finish(&mut self, py: Python<'_>) -> PyResult<()> {
+            let mut guard = self.inner.lock().unwrap();
+            guard.finish(py)
+        }
+    }
+
+    fn run_script(
+        py: Python<'_>,
+        code: &str,
+        file_stem: &str,
+    ) -> PyResult<(Vec<TraceLowLevelEvent>, PathBuf)> {
+        let tmp_dir = tempdir().unwrap();
+        let file_path = tmp_dir.path().join(format!("{file_stem}.py"));
+        fs::write(&file_path, code).unwrap();
+
+        let mut tracer = RuntimeTracer::new("test_program", &[], TraceEventsFileFormat::Json, None);
+
+        let meta_path = tmp_dir.path().join("trace_metadata.json");
+        let paths_path = tmp_dir.path().join("trace_paths.json");
+        let events_path = tmp_dir.path().join("trace.json");
+        tracer.begin(&meta_path, &paths_path, &events_path, &file_path, 1)?;
+
+        let shared = Arc::new(Mutex::new(tracer));
+        install_tracer(
+            py,
+            Box::new(SharedTracer {
+                inner: shared.clone(),
+            }),
+        )?;
+
+        let code_cstr = CString::new(code).unwrap();
+        let filename_cstr = CString::new(file_path.to_str().unwrap()).unwrap();
+        let module_cstr = CString::new("scenario").unwrap();
+        PyModule::from_code(py, &code_cstr, &filename_cstr, &module_cstr)?;
+
+        uninstall_tracer(py)?;
+
+        let events = shared.lock().unwrap().writer.events.clone();
+        Ok((events, file_path))
+    }
+
+    fn collect_line_names(
+        events: &[TraceLowLevelEvent],
+        target_path: &Path,
+    ) -> HashMap<i64, Vec<HashSet<String>>> {
+        let mut paths: Vec<PathBuf> = Vec::new();
+        let mut variable_names: Vec<String> = Vec::new();
+        let mut current: Option<(PathBuf, i64, HashSet<String>)> = None;
+        let mut result: HashMap<i64, Vec<HashSet<String>>> = HashMap::new();
+
+        for event in events {
+            match event {
+                TraceLowLevelEvent::Path(p) => paths.push(p.clone()),
+                TraceLowLevelEvent::VariableName(name) => variable_names.push(name.clone()),
+                TraceLowLevelEvent::Step(step) => {
+                    if let Some((path, line, names)) = current.take() {
+                        if path == target_path {
+                            result.entry(line).or_default().push(names);
+                        }
+                    }
+                    let path = paths
+                        .get(step.path_id.0)
+                        .cloned()
+                        .unwrap_or_else(|| PathBuf::from("<unknown>"));
+                    current = Some((path, step.line.0, HashSet::new()));
+                }
+                TraceLowLevelEvent::Value(full) => {
+                    if let Some((_, _, names)) = current.as_mut() {
+                        if let Some(name) = variable_names.get(full.variable_id.0) {
+                            names.insert(name.clone());
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        if let Some((path, line, names)) = current {
+            if path == target_path {
+                result.entry(line).or_default().push(names);
+            }
+        }
+
+        result
+    }
+
+    fn assert_line_contains(
+        map: &HashMap<i64, Vec<HashSet<String>>>,
+        line: i64,
+        expected: &[&str],
+    ) {
+        let entries = map
+            .get(&line)
+            .unwrap_or_else(|| panic!("no snapshots captured for line {line}"));
+        let mut satisfied = false;
+        for vars in entries {
+            if expected.iter().all(|name| vars.contains(*name)) {
+                satisfied = true;
+                break;
+            }
+        }
+        assert!(
+            satisfied,
+            "line {line} did not contain all expected names {:?}; captured {:?}",
+            expected, entries
+        );
+    }
+
+    fn assert_line_missing(map: &HashMap<i64, Vec<HashSet<String>>>, line: i64, name: &str) {
+        if let Some(entries) = map.get(&line) {
+            for vars in entries {
+                assert!(
+                    !vars.contains(name),
+                    "expected name '{name}' to be absent on line {line}, but captured {:?}",
+                    vars
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn captures_simple_function_locals() {
+        Python::with_gil(|py| -> PyResult<()> {
+            let code = "def simple_function(x):\n    a = 1\n    b = a + x\n    return a, b\n\nresult = simple_function(5)\n";
+            let (events, path) = run_script(py, code, "simple_function")?;
+            let line_map = collect_line_names(&events, &path);
+            assert_line_contains(&line_map, 2, &["x", "a"]);
+            assert_line_contains(&line_map, 3, &["x", "a", "b"]);
+            assert_line_contains(&line_map, 4, &["x", "a", "b"]);
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn captures_closure_and_nonlocals() {
+        Python::with_gil(|py| -> PyResult<()> {
+            let code = "def outer_func(x):\n    y = 1\n    def inner_func(z):\n        nonlocal y\n        w = x + y + z\n        y = w\n        return w\n    total = inner_func(5)\n    return y, total\nresult = outer_func(2)\n";
+            let (events, path) = run_script(py, code, "nested_functions")?;
+            let line_map = collect_line_names(&events, &path);
+            assert_line_contains(&line_map, 5, &["x", "y", "z", "w"]);
+            assert_line_contains(&line_map, 6, &["x", "y", "z", "w"]);
+            assert_line_contains(&line_map, 8, &["x", "y", "total"]);
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn captures_globals_in_function_and_module_scope() {
+        Python::with_gil(|py| -> PyResult<()> {
+            let code = "GLOBAL_VAL = 10\ncounter = 0\n\ndef global_test():\n    local_copy = GLOBAL_VAL\n    global counter\n    counter += 1\n    return local_copy, counter\n\nbefore = counter\nresult = global_test()\nafter = counter\n";
+            let (events, path) = run_script(py, code, "globals")?;
+            let line_map = collect_line_names(&events, &path);
+            assert_line_contains(&line_map, 5, &["local_copy", "GLOBAL_VAL"]);
+            assert_line_contains(&line_map, 7, &["local_copy", "counter", "GLOBAL_VAL"]);
+            assert_line_contains(&line_map, 10, &["before", "counter"]);
+            assert_line_contains(&line_map, 12, &["after", "counter", "result"]);
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn captures_class_body_and_metaclass_variables() {
+        Python::with_gil(|py| -> PyResult<()> {
+            let code = "CONSTANT = 42\n\nclass MetaCounter(type):\n    count = 0\n    def __init__(cls, name, bases, attrs):\n        MetaCounter.count += 1\n        super().__init__(name, bases, attrs)\n\nclass Sample(metaclass=MetaCounter):\n    a = 10\n    b = a + 5\n    print(a, b, CONSTANT)\n    def method(self):\n        return self.a + self.b\n\ninstances = MetaCounter.count\n";
+            let (events, path) = run_script(py, code, "class_scope")?;
+            let line_map = collect_line_names(&events, &path);
+            assert_line_contains(&line_map, 6, &["MetaCounter", "count", "cls", "name"]);
+            assert_line_contains(&line_map, 11, &["a", "b"]);
+            assert_line_contains(&line_map, 12, &["a", "b", "CONSTANT"]);
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn captures_comprehension_and_lambda_scopes() {
+        Python::with_gil(|py| -> PyResult<()> {
+            let code = "factor = 2\ndouble = lambda y: y * factor\nlambda_result = double(3)\nsquares = [n**2 for n in range(3)]\nscaled_set = {n * factor for n in range(3)}\nmapping = {n: n*factor for n in range(3)}\ngen_exp = (n * factor for n in range(3))\nresult_list = list(gen_exp)\n";
+            let (events, path) = run_script(py, code, "comprehensions")?;
+            let line_map = collect_line_names(&events, &path);
+            assert_line_contains(&line_map, 2, &["y", "factor"]);
+            assert_line_contains(&line_map, 4, &["n", "factor"]);
+            assert_line_contains(&line_map, 5, &["n", "factor"]);
+            assert_line_contains(&line_map, 6, &["n", "factor"]);
+            assert_line_contains(&line_map, 7, &["n", "factor"]);
+            assert_line_missing(&line_map, 8, "n");
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn captures_generators_and_coroutines() {
+        Python::with_gil(|py| -> PyResult<()> {
+            let code = "def counter_gen(n):\n    total = 0\n    for i in range(n):\n        total += i\n        yield total\n    return total\n\nimport asyncio\nasync def async_sum(data):\n    total = 0\n    for x in data:\n        total += x\n        await asyncio.sleep(0)\n    return total\n\ngen = counter_gen(3)\ngen_results = list(gen)\ncoroutine_result = asyncio.run(async_sum([1, 2, 3]))\n";
+            let (events, path) = run_script(py, code, "generators")?;
+            let line_map = collect_line_names(&events, &path);
+            assert_line_contains(&line_map, 4, &["total", "i"]);
+            assert_line_contains(&line_map, 5, &["total", "i"]);
+            assert_line_contains(&line_map, 13, &["total", "x"]);
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn captures_exception_and_with_scopes() {
+        Python::with_gil(|py| -> PyResult<()> {
+            let code = "def exception_and_with_demo(x):\n    try:\n        inv = 10 / x\n    except ZeroDivisionError as e:\n        error_msg = f\"Error: {e}\"\n    else:\n        inv += 1\n    finally:\n        final_flag = True\n\n    with open(__file__, 'r') as f:\n        first_line = f.readline()\n    return locals()\n\nresult1 = exception_and_with_demo(0)\nresult2 = exception_and_with_demo(5)\n";
+            let (events, path) = run_script(py, code, "exceptions")?;
+            let line_map = collect_line_names(&events, &path);
+            assert_line_contains(&line_map, 5, &["e", "error_msg"]);
+            assert_line_contains(&line_map, 7, &["inv"]);
+            if let Some(entries) = line_map.get(&9) {
+                for vars in entries {
+                    assert!(!vars.contains("e"));
+                }
+            }
+            assert_line_contains(&line_map, 11, &["f", "first_line"]);
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn captures_decorator_scopes() {
+        Python::with_gil(|py| -> PyResult<()> {
+            let code = "setting = \"Hello\"\n\ndef my_decorator(func):\n    def wrapper(*args, **kwargs):\n        print(\"Decorator wrapping with setting:\", setting)\n        return func(*args, **kwargs)\n    return wrapper\n\n@my_decorator\ndef greet(name):\n    message = f\"Hi, {name}\"\n    return message\n\noutput = greet(\"World\")\n";
+            let (events, path) = run_script(py, code, "decorators")?;
+            let line_map = collect_line_names(&events, &path);
+            assert_line_contains(&line_map, 5, &["args", "kwargs", "setting"]);
+            assert_line_contains(&line_map, 10, &["name", "message"]);
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn captures_dynamic_exec_and_eval() {
+        Python::with_gil(|py| -> PyResult<()> {
+            let code = "expr_code = \"dynamic_var = 99\"\nexec(expr_code)\ncheck = dynamic_var + 1\n\ndef eval_test():\n    value = 10\n    formula = \"value * 2\"\n    result = eval(formula)\n    return result\n\nout = eval_test()\n";
+            let (events, path) = run_script(py, code, "dynamic_exec")?;
+            let line_map = collect_line_names(&events, &path);
+            assert_line_contains(&line_map, 3, &["dynamic_var", "check"]);
+            assert_line_contains(&line_map, 7, &["value", "formula", "result"]);
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn captures_import_visibility() {
+        Python::with_gil(|py| -> PyResult<()> {
+            let code = "import math\n\ndef import_test():\n    import os\n    constant = math.pi\n    cwd = os.getcwd()\n    return constant, cwd\n\nval, path = import_test()\n";
+            let (events, path) = run_script(py, code, "imports")?;
+            let line_map = collect_line_names(&events, &path);
+            assert_line_contains(&line_map, 5, &["constant", "math", "os"]);
+            assert_line_contains(&line_map, 6, &["cwd", "os"]);
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn captures_builtin_usage_without_listing_builtins() {
+        Python::with_gil(|py| -> PyResult<()> {
+            let code = "def builtins_test(seq):\n    n = len(seq)\n    m = max(seq)\n    return n, m\n\nresult = builtins_test([5, 3, 7])\n";
+            let (events, path) = run_script(py, code, "builtins")?;
+            let line_map = collect_line_names(&events, &path);
+            assert_line_contains(&line_map, 2, &["seq", "n"]);
+            assert_line_contains(&line_map, 3, &["seq", "m", "n"]);
+            assert_line_missing(&line_map, 2, "len");
+            assert_line_missing(&line_map, 3, "max");
+            Ok(())
+        })
+        .unwrap();
     }
 }
 
@@ -127,7 +494,9 @@ impl Tracer for RuntimeTracer {
     fn on_py_start(&mut self, py: Python<'_>, code: &CodeObjectWrapper, _offset: i32) {
         // Activate lazily if configured; ignore until then
         self.ensure_started(py, code);
-        if !self.started { return; }
+        if !self.started {
+            return;
+        }
         // Trace event entry
         match (code.filename(py), code.qualname(py)) {
             (Ok(fname), Ok(qname)) => {
@@ -143,7 +512,9 @@ impl Tracer for RuntimeTracer {
     fn on_line(&mut self, py: Python<'_>, code: &CodeObjectWrapper, lineno: u32) {
         // Activate lazily if configured; ignore until then
         self.ensure_started(py, code);
-        if !self.started { return; }
+        if !self.started {
+            return;
+        }
         // Trace event entry
         if let Ok(fname) = code.filename(py) {
             log::debug!("[RuntimeTracer] on_line: {}:{}", fname, lineno);
@@ -152,6 +523,9 @@ impl Tracer for RuntimeTracer {
         }
         if let Ok(filename) = code.filename(py) {
             TraceWriter::register_step(&mut self.writer, Path::new(filename), Line(lineno as i64));
+        }
+        if let Err(err) = self.capture_scope_variables(py, code) {
+            log::warn!("[RuntimeTracer] failed to capture variables: {}", err);
         }
     }
 
@@ -164,15 +538,22 @@ impl Tracer for RuntimeTracer {
     ) {
         // Activate lazily if configured; ignore until then
         self.ensure_started(py, code);
-        if !self.started { return; }
+        if !self.started {
+            return;
+        }
         // Trace event entry
         match (code.filename(py), code.qualname(py)) {
-            (Ok(fname), Ok(qname)) => log::debug!("[RuntimeTracer] on_py_return: {} ({})", qname, fname),
+            (Ok(fname), Ok(qname)) => {
+                log::debug!("[RuntimeTracer] on_py_return: {} ({})", qname, fname)
+            }
             _ => log::debug!("[RuntimeTracer] on_py_return"),
         }
         // Determine whether this is the activation owner's return
-        let is_activation_return = self.activation_code_id.map(|id| id == code.id()).unwrap_or(false);
-        
+        let is_activation_return = self
+            .activation_code_id
+            .map(|id| id == code.id())
+            .unwrap_or(false);
+
         let val = self.encode_value(py, retval);
         TraceWriter::register_return(&mut self.writer, val);
         if is_activation_return {
@@ -204,5 +585,87 @@ impl Tracer for RuntimeTracer {
         TraceWriter::finish_writing_trace_paths(&mut self.writer).map_err(to_py_err)?;
         TraceWriter::finish_writing_trace_events(&mut self.writer).map_err(to_py_err)?;
         Ok(())
+    }
+}
+
+impl RuntimeTracer {
+    fn capture_scope_variables(
+        &mut self,
+        py: Python<'_>,
+        code: &CodeObjectWrapper,
+    ) -> PyResult<()> {
+        unsafe {
+            let tstate = pyo3::ffi::PyThreadState_Get();
+            if tstate.is_null() {
+                return Ok(());
+            }
+
+            let mut frame_ptr = pyo3::ffi::PyThreadState_GetFrame(tstate);
+            if frame_ptr.is_null() {
+                return Ok(());
+            }
+
+            let target_code = code.as_bound(py).as_ptr() as *mut pyo3::ffi::PyCodeObject;
+
+            while !frame_ptr.is_null() {
+                let frame_code = pyo3::ffi::PyFrame_GetCode(frame_ptr);
+                if frame_code == target_code {
+                    let frame_obj =
+                        Py::from_borrowed_ptr(py, frame_ptr.cast::<pyo3::ffi::PyObject>());
+                    let frame_bound = frame_obj.bind(py);
+                    let frame = frame_bound.downcast::<PyFrame>()?;
+                    self.record_frame_variables(py, frame)?;
+                    return Ok(());
+                }
+                frame_ptr = pyo3::ffi::PyFrame_GetBack(frame_ptr);
+            }
+        }
+        Ok(())
+    }
+
+    fn record_frame_variables(
+        &mut self,
+        py: Python<'_>,
+        frame: &Bound<'_, PyFrame>,
+    ) -> PyResult<()> {
+        let locals_any = frame.getattr("f_locals")?;
+        let locals_mapping = locals_any.downcast::<PyMapping>()?;
+        let locals_snapshot = PyDict::new(py);
+        locals_snapshot.update(&locals_mapping)?;
+
+        let globals_any = frame.getattr("f_globals")?;
+        let globals_dict = globals_any.downcast::<PyDict>()?;
+
+        let mut seen = HashSet::new();
+        self.record_dict(py, &locals_snapshot, &mut seen);
+        self.record_dict(py, globals_dict, &mut seen);
+        Ok(())
+    }
+
+    fn record_dict(
+        &mut self,
+        py: Python<'_>,
+        dictionary: &Bound<'_, PyDict>,
+        seen: &mut HashSet<String>,
+    ) {
+        for (key, value) in dictionary.iter() {
+            let Ok(name_obj) = key.str() else { continue };
+            let Ok(name) = name_obj.to_str() else {
+                continue;
+            };
+            if name == "__builtins__" {
+                continue;
+            }
+            let owned_name = name.to_string();
+            if !seen.insert(owned_name.clone()) {
+                continue;
+            }
+            let value_record = self.encode_value(py, &value);
+            TraceWriter::register_variable_with_full_value(
+                &mut self.writer,
+                &owned_name,
+                value_record,
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
- capture locals and globals during LINE events by walking the active frame stack
- add a comprehensive runtime tracer test suite exercising functions, closures, classes, comprehensions, async code, exceptions, decorators, exec/eval, imports, and builtins
- add a tempfile dev dependency used by the new tests

## Testing
- cargo check --manifest-path codetracer-python-recorder/Cargo.toml
- cargo test --manifest-path codetracer-python-recorder/Cargo.toml *(fails: missing libpython symbols in the CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7eaf82b688323adf2d4478718a475