### PR TITLE
ci: migrate ci.yml to self-hosted nixos runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   nix-tests:
     name: Testing on Python ${{matrix.python-version}}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, nixos]
     strategy:
       matrix:
         #python-version: ["3.10","3.11","3.12","3.13"]
@@ -86,7 +86,7 @@ jobs:
   coverage:
     name: Coverage (Python 3.12)
     needs: nix-tests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, nixos]
     continue-on-error: true
     permissions:
       contents: read
@@ -192,7 +192,7 @@ jobs:
 
   nix-build:
     name: Verify nix flake packages build
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, nixos]
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v27


### PR DESCRIPTION
## Summary
- Moves the three ci.yml jobs (`nix-tests`, `coverage`, `nix-build`) off paid `ubuntu-latest` runners onto the metacraft-labs self-hosted NixOS pool.
- The `cachix/install-nix-action` step on the self-hosted nixos hosts is a near no-op because Nix is preinstalled.
- `launcher-integration.yml` and `recorder-release.yml` are intentionally untouched — they install dependencies via apt-get (musl-tools, capnproto), unavailable on the NixOS self-hosted runners; flag them for a separate "nix-ify the install step" PR.

## Test plan
- [ ] Re-run CI on a PR to confirm the migrated jobs land on the self-hosted runner.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>