### PR TITLE
[codex] Migrate Cachix usage to Attic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,11 +54,12 @@ jobs:
             git -C "${GITHUB_WORKSPACE}/../codetracer-trace-format-nim" checkout "${TFN_REF}" 2>/dev/null || true
           fi
 
-      - uses: cachix/install-nix-action@v27
+      - name: Setup Nix
+        uses: metacraft-labs/nixos-modules/.github/setup-nix@main
         with:
-          nix_path: nixpkgs=channel:nixos-25.05
-          extra_nix_config: |
-            experimental-features = nix-command flakes
+          trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
+          substituters: ${{ vars.SUBSTITUTERS }}
+          nix-github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Prepare dev environment
         run: nix develop --command bash -lc 'just venv ${{matrix.python-version}} dev'
 
@@ -131,12 +132,12 @@ jobs:
             git -C "${GITHUB_WORKSPACE}/../codetracer-trace-format-nim" checkout "${TFN_REF}" 2>/dev/null || true
           fi
 
-      - uses: cachix/install-nix-action@v27
+      - name: Setup Nix
+        uses: metacraft-labs/nixos-modules/.github/setup-nix@main
         with:
-          nix_path: nixpkgs=channel:nixos-25.05
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-
+          trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
+          substituters: ${{ vars.SUBSTITUTERS }}
+          nix-github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Prepare dev environment (Python 3.12)
         run: nix develop --command bash -lc 'just venv 3.12 dev'
 
@@ -195,16 +196,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v27
+      - name: Setup Nix
+        uses: metacraft-labs/nixos-modules/.github/setup-nix@main
         with:
-          nix_path: nixpkgs=channel:nixos-25.05
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-
-      # NOTE: .#default (rust-backed recorder) is skipped because
-      # importCargoLock cannot resolve Cargo path dependencies that
-      # reference the external codetracer-trace-format repo.
-      # The nix-tests job already verifies the Rust build via maturin.
-
+          trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
+          substituters: ${{ vars.SUBSTITUTERS }}
+          nix-github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build pure-python recorder
         run: nix build .#codetracer-pure-python-recorder

--- a/.github/workflows/recorder-release.yml
+++ b/.github/workflows/recorder-release.yml
@@ -23,11 +23,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v27
+      - name: Setup Nix
+        uses: metacraft-labs/nixos-modules/.github/setup-nix@main
         with:
-          nix_path: nixpkgs=channel:nixos-25.05
-          extra_nix_config: |
-            experimental-features = nix-command flakes
+          trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
+          substituters: ${{ vars.SUBSTITUTERS }}
+          nix-github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Prepare dev environment (Python 3.13)
         run: nix develop ./nix --command bash -lc 'just venv 3.13 dev'
       - name: Run test suite


### PR DESCRIPTION
## Summary
- replace Cachix cache/deploy usage with Attic cache configuration
- route Nix setup through the shared Attic-aware setup action or repo Attic variables
- remove legacy Cachix push/setup paths where this repo had them

## Validation
- parsed changed GitHub workflow YAML with yq
- parsed changed Nix files with nix-instantiate --parse
- ran git diff --check
