### PR TITLE
ci: mirror CI diagnostics to in-house S3 store

### DIFF
--- a/.github/workflows/ci-reprobuild.yml
+++ b/.github/workflows/ci-reprobuild.yml
@@ -205,5 +205,31 @@ print(f"clingo runtime staged at {ROOT / 'bin'}")
           path: |
             target/
             .repro/
-          retention-days: 7
+          retention-days: 1
           if-no-files-found: ignore
+
+      - name: Mirror test logs to S3 (non-blocking)
+        if: failure()
+        continue-on-error: true
+        uses: metacraft-labs/metacraft-github-actions/mirror-artifacts-s3@main
+        with:
+          path: target/
+          prefix: reprobuild-logs-${{ matrix.os }}-${{ matrix.arch }}/${{ github.run_id }}/target
+          endpoint: ${{ vars.MCL_S3_ARTIFACTS_ENDPOINT }}
+          bucket: ${{ vars.MCL_S3_ARTIFACTS_BUCKET }}
+          region: ${{ vars.MCL_S3_ARTIFACTS_REGION }}
+          access-key-id: ${{ secrets.MCL_S3_ARTIFACTS_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MCL_S3_ARTIFACTS_SECRET_ACCESS_KEY }}
+
+      - name: Mirror reprobuild logs to S3 (non-blocking)
+        if: failure()
+        continue-on-error: true
+        uses: metacraft-labs/metacraft-github-actions/mirror-artifacts-s3@main
+        with:
+          path: .repro/
+          prefix: reprobuild-logs-${{ matrix.os }}-${{ matrix.arch }}/${{ github.run_id }}/repro
+          endpoint: ${{ vars.MCL_S3_ARTIFACTS_ENDPOINT }}
+          bucket: ${{ vars.MCL_S3_ARTIFACTS_BUCKET }}
+          region: ${{ vars.MCL_S3_ARTIFACTS_REGION }}
+          access-key-id: ${{ secrets.MCL_S3_ARTIFACTS_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MCL_S3_ARTIFACTS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,19 @@ jobs:
           path: codetracer-python-recorder/target/coverage/coverage-comment.md
           if-no-files-found: warn
 
+      - name: Mirror coverage artefacts to S3 (non-blocking)
+        if: steps.coverage-run.outcome == 'success'
+        continue-on-error: true
+        uses: metacraft-labs/metacraft-github-actions/mirror-artifacts-s3@main
+        with:
+          path: codetracer-python-recorder/target/coverage/
+          prefix: python-recorder-coverage/${{ github.run_id }}
+          endpoint: ${{ vars.MCL_S3_ARTIFACTS_ENDPOINT }}
+          bucket: ${{ vars.MCL_S3_ARTIFACTS_BUCKET }}
+          region: ${{ vars.MCL_S3_ARTIFACTS_REGION }}
+          access-key-id: ${{ secrets.MCL_S3_ARTIFACTS_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.MCL_S3_ARTIFACTS_SECRET_ACCESS_KEY }}
+
       - name: Comment coverage summary
         if: github.event_name == 'pull_request' && steps.coverage-run.outcome == 'success'
         uses: peter-evans/create-or-update-comment@v4


### PR DESCRIPTION
Adds non-blocking `mirror-artifacts-s3` steps: one mirroring the whole `coverage/` tree after the coverage uploads, and two after the reprobuild-logs upload (target/ + .repro/); drops reprobuild-logs retention 7→1. Part of the in-house S3 artifact-store campaign; best-effort, skips cleanly when the store is unreachable or the repo isn't onboarded.