### PR TITLE
ci: migrate CI to self-hosted eph-* runners

### DIFF
--- a/.github/workflows/recorder-release.yml
+++ b/.github/workflows/recorder-release.yml
@@ -45,29 +45,29 @@ jobs:
       matrix:
         include:
           - name: linux-x86_64
-            os: ubuntu-latest
+            os: eph-linux-x64
             build-sdist: true
             publish-args: --release --sdist --interpreter python3.12 python3.13 --out dist
             manylinux: 2014
             target: ""
           - name: linux-aarch64
-            os: ubuntu-latest
+            os: eph-linux-x64
             build-sdist: false
             publish-args: --release --interpreter python3.12 python3.13 --target aarch64-unknown-linux-gnu --out dist
             manylinux: 2014
             target: ""
           - name: macos-x86_64
-            os: macos-13
+            os: eph-macos-arm64
             build-sdist: false
             publish-args: --release --out dist --interpreter python3.12 python3.13
             target: x86_64
           - name: macos-aarch64
-            os: macos-14
+            os: eph-macos-arm64
             build-sdist: false
             publish-args: --release --out dist --interpreter python3.12 python3.13
             target: aarch64
           - name: windows-amd64
-            os: windows-latest
+            os: eph-win-x64
             build-sdist: false
             publish-args: --release --out dist
             target: ""


### PR DESCRIPTION
Migrate GitHub-hosted CI runners to Metacraft Labs self-hosted `eph-*` classes, per org policy (all CI on self-hosted eph-* classes; GitHub-hosted not permitted).

`recorder-release.yml` per-OS wheel build matrix:

- `linux-x86_64`: `ubuntu-latest` → `eph-linux-x64`
- `linux-aarch64`: `ubuntu-latest` → `eph-linux-x64`
- `macos-x86_64`: `macos-13` → `eph-macos-arm64`
- `macos-aarch64`: `macos-14` → `eph-macos-arm64`
- `windows-amd64`: `windows-latest` → `eph-win-x64`

## Architecture change note (Intel macOS)

The `macos-x86_64` leg previously ran on `macos-13`, a GitHub-hosted **Intel** macOS runner. There is no Intel-mac self-hosted runner in the `eph-*` pool, so this leg now maps to `eph-macos-arm64` and will **build on Apple Silicon**. The matrix `name`/`target` fields (`macos-x86_64`, `target: x86_64`) are unchanged, so the leg still declares an x86_64 maturin target — it is now cross/native-arch built on an arm64 host rather than natively on Intel hardware. Downstream packaging that assumes native Intel builds should be reviewed.

Only GitHub-hosted runner labels were changed. All `[self-hosted, nixos]` and other self-hosted entries in this repo's other workflows are untouched; YAML/matrix structure preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)