### PR TITLE
ci: drop Intel-mac (x86_64 macOS) wheel build

### DIFF
--- a/.github/workflows/recorder-release.yml
+++ b/.github/workflows/recorder-release.yml
@@ -56,11 +56,6 @@ jobs:
             publish-args: --release --interpreter python3.12 python3.13 --target aarch64-unknown-linux-gnu --out dist
             manylinux: 2014
             target: ""
-          - name: macos-x86_64
-            os: eph-macos-arm64
-            build-sdist: false
-            publish-args: --release --out dist --interpreter python3.12 python3.13
-            target: x86_64
           - name: macos-aarch64
             os: eph-macos-arm64
             build-sdist: false


### PR DESCRIPTION
Drops the `macos-x86_64` (Intel / x86_64 macOS) wheel-build matrix leg from `recorder-release.yml`. The recent runner migration collapsed the Intel-mac leg onto Apple Silicon (`eph-macos-arm64`), so this leg is now redundant.

Removed the entire matrix `include:` entry (name, os, build-sdist, publish-args, target: x86_64). The `macos-aarch64` leg and all Linux/Windows legs are retained. Artifact names are dynamic (`dist-${{ matrix.name }}`) and downloads use the `dist-*` pattern, so no `needs:`/upload-download/publish-glob references dangle.