### PR TITLE
ci: build linux-aarch64 wheel natively on eph-linux-arm64

### DIFF
--- a/.github/workflows/recorder-release.yml
+++ b/.github/workflows/recorder-release.yml
@@ -51,9 +51,9 @@ jobs:
             manylinux: 2014
             target: ""
           - name: linux-aarch64
-            os: eph-linux-x64
+            os: eph-linux-arm64
             build-sdist: false
-            publish-args: --release --interpreter python3.12 python3.13 --target aarch64-unknown-linux-gnu --out dist
+            publish-args: --release --interpreter python3.12 python3.13 --out dist
             manylinux: 2014
             target: ""
           - name: macos-aarch64


### PR DESCRIPTION
The `linux-aarch64` wheel leg ran on `eph-linux-x64` and cross-built via maturin-action's `--target aarch64-unknown-linux-gnu` — i.e. a QEMU-emulated `manylinux2014_aarch64` build, the fragile path for a PyO3 extension with C deps (Cap'n Proto, zstd FFI). Now that a native `eph-linux-arm64` self-hosted class exists (from the runner migration), this builds the aarch64 wheel **natively** on it and drops the cross-target flag, so maturin runs the `manylinux2014_aarch64` container without emulation. `manylinux: 2014` + `before-script-linux` (capnproto install) are unchanged and now run natively in-container.