### PR TITLE
ci: build-only validation path for the release workflow

### DIFF
--- a/.github/workflows/recorder-release.yml
+++ b/.github/workflows/recorder-release.yml
@@ -5,6 +5,18 @@ on:
     tags:
       - recorder-v*
   workflow_dispatch:
+    inputs:
+      publish_testpypi:
+        description: >-
+          Also publish the built artefacts to TestPyPI. Default is a
+          build-only validation run (verify + build all matrix legs +
+          upload artefacts) that publishes NOTHING — use it to confirm a
+          workflow or runner change (e.g. the native eph-linux-arm64
+          wheel build) still produces wheels without risking a release.
+          PyPI (production) is never published from a manual dispatch;
+          only a `recorder-v*` tag push does that.
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -213,6 +225,11 @@ jobs:
   publish-testpypi:
     name: Publish to TestPyPI
     needs: build
+    # Publish on a real tag push, or on a manual dispatch only when the
+    # operator explicitly opts in. A plain workflow_dispatch is a build-only
+    # validation run (verify + build + upload artefacts) that publishes
+    # nothing.
+    if: startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && inputs.publish_testpypi)
     runs-on: [self-hosted, nixos]
     environment:
       name: testpypi


### PR DESCRIPTION
Follow-up to #81 (native eph-linux-arm64 wheel). `recorder-release.yml` only builds the wheels on tag push / workflow_dispatch, and a plain dispatch previously **published to TestPyPI** (publish-testpypi had no event gate) — so there was no safe way to validate a build/runner change.

This adds a boolean `workflow_dispatch` input `publish_testpypi` (default **false**) and gates `publish-testpypi` on `tag-push OR that opt-in`. Now:
- **Default manual dispatch** → verify + build **all** matrix legs (incl. the native `linux-aarch64` on `eph-linux-arm64`) + `upload-artifact` (`if-no-files-found: error`) → publishes **nothing**. This is the safe validation run.
- **Manual dispatch with `publish_testpypi: true`** → also publishes to TestPyPI (the old dispatch behavior, now opt-in).
- **`recorder-v*` tag push** → full pipeline unchanged (TestPyPI → PyPI production).

PyPI production is still tag-only. actionlint-clean.