### PR TITLE
ci: fix release verify job — use root dev shell (just not found)

### DIFF
--- a/.github/workflows/recorder-release.yml
+++ b/.github/workflows/recorder-release.yml
@@ -42,11 +42,11 @@ jobs:
           substituters: ${{ vars.SUBSTITUTERS }}
           nix-github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Prepare dev environment (Python 3.13)
-        run: nix develop ./nix --command bash -lc 'just venv 3.13 dev'
+        run: nix develop --command bash -lc 'just venv 3.13 dev'
       - name: Run test suite
-        run: nix develop ./nix --command bash -lc 'just test'
+        run: nix develop --command bash -lc 'just test'
       - name: Check recorder version parity
-        run: nix develop ./nix --command bash -lc 'python3 scripts/check_recorder_version.py'
+        run: nix develop --command bash -lc 'python3 scripts/check_recorder_version.py'
 
   build:
     name: Build Artefacts (${{ matrix.name }})


### PR DESCRIPTION
The Recorder Release `verify` job ran under `nix develop ./nix` — the `./nix` consumer/packaging sub-flake (per `nix/USAGE_EXAMPLE.md`), whose devShell lacks `just`, so it failed immediately with `just: command not found` and (via `needs: verify`) blocked the whole build matrix. The working `ci.yml` uses the **root** flake dev shell (`nix develop`). This switches verify's three steps to `nix develop` to match. Surfaced by the build-only validation dispatch added in #82.