### PR TITLE
ci: fix repo-wide 'just: command not found' (drop login shell in nix develop)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
           substituters: ${{ vars.SUBSTITUTERS }}
           nix-github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Prepare dev environment
-        run: nix develop --command bash -lc 'just venv ${{matrix.python-version}} dev'
+        run: nix develop --command bash -c 'just venv ${{matrix.python-version}} dev'
 
       - name: Build ct-print binary
         # tests/python/test_cli_integration.py shells out to
@@ -70,19 +70,19 @@ jobs:
         # pure-python recorder reference oracle.  Compile it from
         # codetracer_ct_print.nim into the expected path.
         run: |
-          nix develop --command bash -lc '
+          nix develop --command bash -c '
             cd "${GITHUB_WORKSPACE}/../codetracer-trace-format-nim"
             nim c -d:release -p:src -o:ct-print src/codetracer_ct_print.nim
           '
 
       - name: Verify recorder version metadata
-        run: nix develop --command bash -lc 'python3 scripts/check_recorder_version.py'
+        run: nix develop --command bash -c 'python3 scripts/check_recorder_version.py'
 
       - name: Rust tests
-        run: nix develop --command bash -lc 'just cargo-test'
+        run: nix develop --command bash -c 'just cargo-test'
 
       - name: Python tests
-        run: nix develop --command bash -lc 'just py-test'
+        run: nix develop --command bash -c 'just py-test'
 
   coverage:
     name: Coverage (Python 3.12)
@@ -139,17 +139,17 @@ jobs:
           substituters: ${{ vars.SUBSTITUTERS }}
           nix-github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Prepare dev environment (Python 3.12)
-        run: nix develop --command bash -lc 'just venv 3.12 dev'
+        run: nix develop --command bash -c 'just venv 3.12 dev'
 
       - name: Collect coverage
         id: coverage-run
-        run: nix develop --command bash -lc 'just coverage'
+        run: nix develop --command bash -c 'just coverage'
 
       - name: Generate coverage comment
         if: steps.coverage-run.outcome == 'success'
         run: |
           ROOT="$(pwd)"
-          nix develop --command bash -lc "python3 codetracer-python-recorder/scripts/generate_coverage_comment.py \
+          nix develop --command bash -c "python3 codetracer-python-recorder/scripts/generate_coverage_comment.py \
             --rust-summary codetracer-python-recorder/target/coverage/rust/summary.json \
             --python-json codetracer-python-recorder/target/coverage/python/coverage.json \
             --output codetracer-python-recorder/target/coverage/coverage-comment.md \

--- a/.github/workflows/recorder-release.yml
+++ b/.github/workflows/recorder-release.yml
@@ -42,11 +42,11 @@ jobs:
           substituters: ${{ vars.SUBSTITUTERS }}
           nix-github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Prepare dev environment (Python 3.13)
-        run: nix develop --command bash -lc 'just venv 3.13 dev'
+        run: nix develop --command bash -c 'just venv 3.13 dev'
       - name: Run test suite
-        run: nix develop --command bash -lc 'just test'
+        run: nix develop --command bash -c 'just test'
       - name: Check recorder version parity
-        run: nix develop --command bash -lc 'python3 scripts/check_recorder_version.py'
+        run: nix develop --command bash -c 'python3 scripts/check_recorder_version.py'
 
   build:
     name: Build Artefacts (${{ matrix.name }})


### PR DESCRIPTION
**Repo-wide CI breakage.** Every step ran `nix develop --command bash -lc '…'`. The `-l` login flag re-sources `/etc/profile`, which on the NixOS runners **overwrites `PATH`** with the system profile and discards what `nix develop` just added — so `just` (which *is* in the root devShell) wasn't found, and every step failed at once with `just: command not found`. This hit `ci.yml`'s Testing/Coverage jobs **and** `recorder-release.yml`'s verify job — the CI has been failing at env-setup, not at the tests.

Fix: use non-login `bash -c` so the dev-shell `PATH` survives. 11 call sites across both workflows. Surfaced while adding the build-only release validation path (#82) and fixing the verify devshell (#83).