### PR TITLE
ci: repair the recorder-release pipeline (siblings, ct-print, nix-native build)

### DIFF
--- a/.github/workflows/recorder-release.yml
+++ b/.github/workflows/recorder-release.yml
@@ -100,6 +100,13 @@ jobs:
   build:
     name: Build Artefacts (${{ matrix.name }})
     needs: verify
+    # Real releases (tag pushes) gate the build on a green test suite. A
+    # manual build-only validation dispatch, however, exercises the build
+    # even when verify fails — you are validating that the wheels BUILD
+    # (e.g. after a runner/packaging change), not the test outcome.
+    # Publishing stays gated on tags / explicit opt-in regardless (see the
+    # publish-* jobs), so a dispatch never releases anything.
+    if: always() && (needs.verify.result == 'success' || github.event_name == 'workflow_dispatch')
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/recorder-release.yml
+++ b/.github/workflows/recorder-release.yml
@@ -35,6 +35,45 @@ jobs:
     runs-on: [self-hosted, nixos]
     steps:
       - uses: actions/checkout@v4
+
+      # The recorder crate path-depends on the codetracer-trace-format
+      # sibling (codetracer_ctfs / codetracer_trace_* at ../../) and the
+      # codetracer-trace-format-nim FFI source. Clone them next to the
+      # checkout, exactly like ci.yml, so `just test` / maturin can build.
+      - name: Clone codetracer-trace-format (Cargo path dependency)
+        run: |
+          PINS=".github/sibling-pins"
+          TF_REF="main"
+          if [ -f "${PINS}" ]; then
+            PIN="$(grep '^codetracer-trace-format ' "${PINS}" | cut -d' ' -f2)" || true
+            [ -n "${PIN}" ] && TF_REF="${PIN}"
+          fi
+          rm -rf "${GITHUB_WORKSPACE}/../codetracer-trace-format"
+          git clone --depth 1 \
+            "https://github.com/metacraft-labs/codetracer-trace-format.git" \
+            "${GITHUB_WORKSPACE}/../codetracer-trace-format"
+          if [ "${TF_REF}" != "main" ]; then
+            git -C "${GITHUB_WORKSPACE}/../codetracer-trace-format" fetch origin "${TF_REF}" 2>/dev/null || true
+            git -C "${GITHUB_WORKSPACE}/../codetracer-trace-format" checkout "${TF_REF}" 2>/dev/null || true
+          fi
+
+      - name: Clone codetracer-trace-format-nim (Nim FFI source)
+        run: |
+          PINS=".github/sibling-pins"
+          TFN_REF="main"
+          if [ -f "${PINS}" ]; then
+            PIN="$(grep '^codetracer-trace-format-nim ' "${PINS}" | cut -d' ' -f2)" || true
+            [ -n "${PIN}" ] && TFN_REF="${PIN}"
+          fi
+          rm -rf "${GITHUB_WORKSPACE}/../codetracer-trace-format-nim"
+          git clone --depth 1 \
+            "https://github.com/metacraft-labs/codetracer-trace-format-nim.git" \
+            "${GITHUB_WORKSPACE}/../codetracer-trace-format-nim"
+          if [ "${TFN_REF}" != "main" ]; then
+            git -C "${GITHUB_WORKSPACE}/../codetracer-trace-format-nim" fetch origin "${TFN_REF}" 2>/dev/null || true
+            git -C "${GITHUB_WORKSPACE}/../codetracer-trace-format-nim" checkout "${TFN_REF}" 2>/dev/null || true
+          fi
+
       - name: Setup Nix
         uses: metacraft-labs/nixos-modules/.github/setup-nix@main
         with:
@@ -80,6 +119,49 @@ jobs:
             target: ""
     steps:
       - uses: actions/checkout@v4
+
+      # The recorder crate path-depends on the codetracer-trace-format
+      # sibling (codetracer_ctfs / codetracer_trace_* at ../../) and the
+      # codetracer-trace-format-nim FFI source. Clone them next to the
+      # checkout so maturin can resolve the path dependencies.
+      - name: Clone codetracer-trace-format (Cargo path dependency)
+        if: startsWith(matrix.name, 'linux-') || startsWith(matrix.name, 'macos-') || matrix.name == 'windows-amd64'
+        shell: bash
+        run: |
+          PINS=".github/sibling-pins"
+          TF_REF="main"
+          if [ -f "${PINS}" ]; then
+            PIN="$(grep '^codetracer-trace-format ' "${PINS}" | cut -d' ' -f2)" || true
+            [ -n "${PIN}" ] && TF_REF="${PIN}"
+          fi
+          rm -rf "${GITHUB_WORKSPACE}/../codetracer-trace-format"
+          git clone --depth 1 \
+            "https://github.com/metacraft-labs/codetracer-trace-format.git" \
+            "${GITHUB_WORKSPACE}/../codetracer-trace-format"
+          if [ "${TF_REF}" != "main" ]; then
+            git -C "${GITHUB_WORKSPACE}/../codetracer-trace-format" fetch origin "${TF_REF}" 2>/dev/null || true
+            git -C "${GITHUB_WORKSPACE}/../codetracer-trace-format" checkout "${TF_REF}" 2>/dev/null || true
+          fi
+
+      - name: Clone codetracer-trace-format-nim (Nim FFI source)
+        if: startsWith(matrix.name, 'linux-') || startsWith(matrix.name, 'macos-') || matrix.name == 'windows-amd64'
+        shell: bash
+        run: |
+          PINS=".github/sibling-pins"
+          TFN_REF="main"
+          if [ -f "${PINS}" ]; then
+            PIN="$(grep '^codetracer-trace-format-nim ' "${PINS}" | cut -d' ' -f2)" || true
+            [ -n "${PIN}" ] && TFN_REF="${PIN}"
+          fi
+          rm -rf "${GITHUB_WORKSPACE}/../codetracer-trace-format-nim"
+          git clone --depth 1 \
+            "https://github.com/metacraft-labs/codetracer-trace-format-nim.git" \
+            "${GITHUB_WORKSPACE}/../codetracer-trace-format-nim"
+          if [ "${TFN_REF}" != "main" ]; then
+            git -C "${GITHUB_WORKSPACE}/../codetracer-trace-format-nim" fetch origin "${TFN_REF}" 2>/dev/null || true
+            git -C "${GITHUB_WORKSPACE}/../codetracer-trace-format-nim" checkout "${TFN_REF}" 2>/dev/null || true
+          fi
+
       - name: Check recorder version parity
         shell: bash
         run: |

--- a/.github/workflows/recorder-release.yml
+++ b/.github/workflows/recorder-release.yml
@@ -82,6 +82,16 @@ jobs:
           nix-github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Prepare dev environment (Python 3.13)
         run: nix develop --command bash -c 'just venv 3.13 dev'
+      - name: Build ct-print binary
+        # The integration tests shell out to
+        # ../codetracer-trace-format-nim/ct-print to decode CTFS bundles
+        # back into the legacy JSON shape (see ci.yml). Compile it from
+        # codetracer_ct_print.nim into the expected path.
+        run: |
+          nix develop --command bash -c '
+            cd "${GITHUB_WORKSPACE}/../codetracer-trace-format-nim"
+            nim c -d:release -p:src -o:ct-print src/codetracer_ct_print.nim
+          '
       - name: Run test suite
         run: nix develop --command bash -c 'just test'
       - name: Check recorder version parity

--- a/.github/workflows/recorder-release.yml
+++ b/.github/workflows/recorder-release.yml
@@ -222,30 +222,30 @@ jobs:
             exit 1
           fi
 
-      - name: Build artefacts (Linux targets)
+      - name: Setup Nix
         if: startsWith(matrix.name, 'linux-')
-        uses: PyO3/maturin-action@v1
+        uses: metacraft-labs/nixos-modules/.github/setup-nix@main
         with:
-          command: build
-          args: ${{ matrix.publish-args }}
-          manylinux: ${{ matrix.manylinux }}
-          sccache: true
-          before-script-linux: |
-            set -eux
-            if command -v yum >/dev/null 2>&1; then
-              yum install -y capnproto
-            elif command -v dnf >/dev/null 2>&1; then
-              dnf install -y capnproto
-            elif command -v microdnf >/dev/null 2>&1; then
-              microdnf install -y capnproto
-            elif command -v apt-get >/dev/null 2>&1; then
-              apt-get update
-              apt-get install -y capnproto
-            else
-              echo "Unable to install capnproto: no supported package manager found" >&2
-              exit 1
-            fi
-          working-directory: codetracer-python-recorder
+          trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
+          substituters: ${{ vars.SUBSTITUTERS }}
+          nix-github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build artefacts (Linux targets)
+        # The eph-linux-* self-hosted runners are NixOS VMs without a Docker
+        # daemon, so maturin's manylinux container build cannot run. Build in
+        # the repo's nix dev shell instead — it provides maturin, the Rust
+        # toolchain and capnproto, and the trace-format siblings are cloned
+        # next to the checkout. NOTE: this produces host-glibc (nixpkgs) wheels
+        # tagged linux_<arch>, NOT manylinux — fine for validating that the
+        # native (incl. eph-linux-arm64) build compiles, but PyPI needs a
+        # manylinux strategy (Docker on the runners, or auditwheel) before this
+        # feeds a real publish. See PR description.
+        if: startsWith(matrix.name, 'linux-')
+        run: |
+          nix develop --command bash -c '
+            cd codetracer-python-recorder
+            maturin build ${{ matrix.publish-args }}
+          '
 
       - name: Install Python 3.12 (macOS)
         if: startsWith(matrix.name, 'macos-')


### PR DESCRIPTION
Repairs the recorder-release pipeline, which had been broken since the post-v0.3.0 CTFS refactor + the CIP-5 self-hosted migration (only tag runs exercised it, so it went unnoticed):

- **Clone trace-format siblings** in verify + build (the crate now path-depends on `codetracer_ctfs`/`codetracer_trace_*` at ../../).
- **Build ct-print** in verify (28 integration tests shell out to it).
- **Build Linux wheels in the nix dev shell** — the `eph-linux-*` runners are NixOS VMs with no Docker, so maturin's manylinux container can't run. The nix build has maturin + Rust + capnproto + the siblings.
- **Build-only dispatch** runs the build even if the suite is red (validating that wheels BUILD); real tag releases still gate on green tests; publishing stays tag/opt-in gated.

Validated: verify goes green, and the linux-x86_64 leg builds cp312+cp313 wheels via nix. FOLLOW-UP (next PR): make the nix wheels portable across distros with `maturin --zig` (manylinux2014) — currently they're tagged `linux_x86_64`, not manylinux.