### PR TITLE
ci: repin metacraft-github-actions actions from @main to @dev

### DIFF
--- a/.github/workflows/ci-reprobuild.yml
+++ b/.github/workflows/ci-reprobuild.yml
@@ -89,7 +89,7 @@ jobs:
           owner: metacraft-labs
 
       - name: Setup dev env (reprobuild flavor)
-        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
+        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@dev
         with:
           env-flavor: reprobuild
           repro-build-pin: codex/attic-ci-cache-vars
@@ -211,7 +211,7 @@ print(f"clingo runtime staged at {ROOT / 'bin'}")
       - name: Mirror test logs to S3 (non-blocking)
         if: failure()
         continue-on-error: true
-        uses: metacraft-labs/metacraft-github-actions/mirror-artifacts-s3@main
+        uses: metacraft-labs/metacraft-github-actions/mirror-artifacts-s3@dev
         with:
           path: target/
           prefix: reprobuild-logs-${{ matrix.os }}-${{ matrix.arch }}/${{ github.run_id }}/target
@@ -224,7 +224,7 @@ print(f"clingo runtime staged at {ROOT / 'bin'}")
       - name: Mirror reprobuild logs to S3 (non-blocking)
         if: failure()
         continue-on-error: true
-        uses: metacraft-labs/metacraft-github-actions/mirror-artifacts-s3@main
+        uses: metacraft-labs/metacraft-github-actions/mirror-artifacts-s3@dev
         with:
           path: .repro/
           prefix: reprobuild-logs-${{ matrix.os }}-${{ matrix.arch }}/${{ github.run_id }}/repro

--- a/.github/workflows/ci-windows-diy.yml
+++ b/.github/workflows/ci-windows-diy.yml
@@ -84,7 +84,7 @@ jobs:
           owner: metacraft-labs
 
       - name: Setup dev env (windows-diy flavor)
-        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
+        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@dev
         with:
           env-flavor: windows-diy
           gh-token: ${{ steps.ci_token.outputs.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         # setup-dev-env clones the siblings listed in .github/sibling-repos
         # (codetracer-trace-format, codetracer-trace-format-nim) at the
         # workspace-lock-pinned revisions before materialising the nix env.
-        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
+        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@dev
         with:
           env-flavor: nix
           gh-token: ${{ steps.app-token.outputs.token }}
@@ -88,7 +88,7 @@ jobs:
         # setup-dev-env clones the siblings listed in .github/sibling-repos
         # (codetracer-trace-format, codetracer-trace-format-nim) at the
         # workspace-lock-pinned revisions before materialising the nix env.
-        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
+        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@dev
         with:
           env-flavor: nix
           gh-token: ${{ steps.app-token.outputs.token }}
@@ -146,7 +146,7 @@ jobs:
       - name: Mirror coverage artefacts to S3 (non-blocking)
         if: steps.coverage-run.outcome == 'success'
         continue-on-error: true
-        uses: metacraft-labs/metacraft-github-actions/mirror-artifacts-s3@main
+        uses: metacraft-labs/metacraft-github-actions/mirror-artifacts-s3@dev
         with:
           path: codetracer-python-recorder/target/coverage/
           prefix: python-recorder-coverage/${{ github.run_id }}
@@ -179,7 +179,7 @@ jobs:
           owner: metacraft-labs
 
       - name: Setup dev env
-        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
+        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@dev
         with:
           env-flavor: nix
           gh-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/launcher-integration.yml
+++ b/.github/workflows/launcher-integration.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           path: codetracer-python-recorder
 
-      - uses: metacraft-labs/metacraft-github-actions/clone-repo@main
+      - uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
         with:
           repo: metacraft-labs/codetracer-launcher
           ref: main


### PR DESCRIPTION
After the org-wide `main`->`dev` rename of `metacraft-labs/metacraft-github-actions`, its old `main` branch no longer resolves for GitHub Actions (`git/ref/heads/main` 404s; `@main` fails at action-load). This repins every `uses: metacraft-labs/metacraft-github-actions/<action>@main` here to `@dev` (the new mainline).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>